### PR TITLE
Replace magic strings and numbers with named constants

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,10 +1,19 @@
 import { NextResponse } from "next/server";
+import {
+  ENV_BRIDGE_CONTRACT_ID,
+  ENV_MOONPAY_API_KEY,
+  ENV_TRANSAK_API_KEY,
+  ENV_STELLAR_NETWORK,
+  STATUS_CONFIGURED,
+  STATUS_MISSING,
+  DEFAULT_NETWORK,
+} from "@/lib/constants";
 
 export async function GET() {
   return NextResponse.json({
-    bridgeContractId: process.env.NEXT_PUBLIC_BRIDGE_CONTRACT_ID ? "configured" : "missing",
-    moonpayApiKey: process.env.NEXT_PUBLIC_MOONPAY_API_KEY ? "configured" : "missing",
-    transakApiKey: process.env.NEXT_PUBLIC_TRANSAK_API_KEY ? "configured" : "missing",
-    stellarNetwork: process.env.NEXT_PUBLIC_STELLAR_NETWORK || "TESTNET",
+    bridgeContractId: process.env[ENV_BRIDGE_CONTRACT_ID] ? STATUS_CONFIGURED : STATUS_MISSING,
+    moonpayApiKey: process.env[ENV_MOONPAY_API_KEY] ? STATUS_CONFIGURED : STATUS_MISSING,
+    transakApiKey: process.env[ENV_TRANSAK_API_KEY] ? STATUS_CONFIGURED : STATUS_MISSING,
+    stellarNetwork: process.env[ENV_STELLAR_NETWORK] || DEFAULT_NETWORK,
   });
 }

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -14,8 +14,35 @@ import {
   loadAccountInfo,
   buildAndSubmitChangeTrust,
   getTransactionStatus,
-  USDC_ISSUERS,
 } from "@/lib/stellar";
+import {
+  ASSET_XLM,
+  ASSET_USDC,
+  XLM_RESERVE_BUFFER,
+  XLM_DISPLAY_DECIMALS,
+  XLM_PRECISE_DECIMALS,
+  STELLAR_ADDRESS_LENGTH,
+  NETWORK_PUBLIC,
+  NETWORK_TESTNET,
+  NETWORK_DISPLAY,
+  TX_MAX_ATTEMPTS,
+  TX_POLL_INTERVAL_MS,
+  STATUS_IDLE,
+  STATUS_SIGNING,
+  STATUS_SUBMITTING,
+  STATUS_SUCCESS,
+  STATUS_ERROR,
+  STATUS_PENDING,
+  STATUS_CONFIRMED,
+  STATUS_FAILED,
+  STATUS_UNKNOWN,
+  STATUS_HAS,
+  STATUS_MISSING,
+  STEP_FORM,
+  STEP_REVIEW,
+  STEP_CONFIRM,
+  USDC_ISSUERS,
+} from "@/lib/constants";
 
 type Step = "form" | "review" | "confirm";
 type TxStatus = "idle" | "signing" | "submitting" | "success" | "error";
@@ -26,9 +53,9 @@ export default function BridgePage() {
   const [fromAddress, setFromAddress] = useState("");
   const [toAddress, setToAddress] = useState("");
   const [amount, setAmount] = useState("");
-  const [asset, setAsset] = useState("XLM");
-  const [step, setStep] = useState<Step>("form");
-  const [txStatus, setTxStatus] = useState<TxStatus>("idle");
+  const [asset, setAsset] = useState<string>(ASSET_XLM);
+  const [step, setStep] = useState<Step>(STEP_FORM);
+  const [txStatus, setTxStatus] = useState<TxStatus>(STATUS_IDLE);
   const [txHash, setTxHash] = useState<string | null>(null);
   const [txError, setTxError] = useState<string | null>(null);
 
@@ -50,20 +77,20 @@ export default function BridgePage() {
   // --- Computed values (derived from state, no extra renders needed) ---
 
   const trustlineStatus: "unknown" | "has" | "missing" =
-    asset !== "USDC" || accountExists !== true
-      ? "unknown"
-      : allBalances.some((b) => b.asset === "USDC") ? "has" : "missing";
+    asset !== ASSET_USDC || accountExists !== true
+      ? STATUS_UNKNOWN
+      : allBalances.some((b) => b.asset === ASSET_USDC) ? STATUS_HAS : STATUS_MISSING;
 
   const balanceError = (() => {
     if (!amount || allBalances.length === 0) return null;
     const n = parseFloat(amount);
     if (isNaN(n) || n <= 0) return null;
-    if (asset === "XLM") {
-      const xlmBal = parseFloat(allBalances.find((b) => b.asset === "XLM")?.amount ?? "0");
-      if (n > xlmBal - 0.00001) return `Insufficient XLM balance. You have ${xlmBal.toFixed(7)} XLM`;
-    } else if (asset === "USDC") {
-      const usdcBal = parseFloat(allBalances.find((b) => b.asset === "USDC")?.amount ?? "0");
-      if (n > usdcBal) return `Insufficient USDC balance. You have ${usdcBal.toFixed(2)} USDC`;
+    if (asset === ASSET_XLM) {
+      const xlmBal = parseFloat(allBalances.find((b) => b.asset === ASSET_XLM)?.amount ?? "0");
+      if (n > xlmBal - XLM_RESERVE_BUFFER) return `Insufficient ${ASSET_XLM} balance. You have ${xlmBal.toFixed(XLM_PRECISE_DECIMALS)} ${ASSET_XLM}`;
+    } else if (asset === ASSET_USDC) {
+      const usdcBal = parseFloat(allBalances.find((b) => b.asset === ASSET_USDC)?.amount ?? "0");
+      if (n > usdcBal) return `Insufficient ${ASSET_USDC} balance. You have ${usdcBal.toFixed(XLM_DISPLAY_DECIMALS)} ${ASSET_USDC}`;
     }
     return null;
   })();
@@ -80,7 +107,7 @@ export default function BridgePage() {
         if (!ignore) {
           setAccountExists(info.exists);
           setAllBalances(info.balances);
-          setSourceBalance(info.balances.find((b) => b.asset === "XLM")?.amount ?? "0");
+          setSourceBalance(info.balances.find((b) => b.asset === ASSET_XLM)?.amount ?? "0");
         }
       } catch {
         if (!ignore) {
@@ -110,7 +137,7 @@ export default function BridgePage() {
     setPollTimedOut(false);
 
     let attempts = 0;
-    const maxAttempts = 24; // 24 × 5 s = 120 s
+    const maxAttempts = TX_MAX_ATTEMPTS;
 
     const doPoll = async () => {
       if (!pollActiveRef.current) return;
@@ -123,12 +150,12 @@ export default function BridgePage() {
         const status = await getTransactionStatus(hash, network);
         if (!pollActiveRef.current) return;
         setPollStatus(status);
-        if (status === "pending") {
-          pollTimeoutRef.current = setTimeout(doPoll, 5000);
+        if (status === STATUS_PENDING) {
+          pollTimeoutRef.current = setTimeout(doPoll, TX_POLL_INTERVAL_MS);
         }
       } catch {
         if (pollActiveRef.current) {
-          pollTimeoutRef.current = setTimeout(doPoll, 5000);
+          pollTimeoutRef.current = setTimeout(doPoll, TX_POLL_INTERVAL_MS);
         }
       }
     };
@@ -148,10 +175,10 @@ export default function BridgePage() {
     validFrom &&
     validTo &&
     validAmount &&
-    txStatus === "idle" &&
+    txStatus === STATUS_IDLE &&
     accountExists !== false &&
     !balanceError &&
-    trustlineStatus !== "missing";
+    trustlineStatus !== STATUS_MISSING;
 
   // --- Handlers ---
 
@@ -161,53 +188,53 @@ export default function BridgePage() {
 
   const handleSubmit = () => {
     if (!canProceed) return;
-    setStep("review");
+    setStep(STEP_REVIEW);
     setTxError(null);
   };
 
   const handleConfirm = async () => {
     if (!fromAddress || !toAddress || !amount) return;
-    setTxStatus("signing");
+    setTxStatus(STATUS_SIGNING);
     setTxError(null);
     try {
       const result = await bridgeViaContract(fromAddress, toAddress, amount, asset, network);
       setTxHash(result.hash);
-      setTxStatus("success");
-      setStep("confirm");
+      setTxStatus(STATUS_SUCCESS);
+      setStep(STEP_CONFIRM);
       startPolling(result.hash);
     } catch (e: unknown) {
       setTxError(e instanceof Error ? e.message : "Transaction failed");
-      setTxStatus("error");
+      setTxStatus(STATUS_ERROR);
     }
   };
 
   const handleAddTrustline = async () => {
     if (!fromAddress) return;
-    setTrustlineActionStatus("signing");
+    setTrustlineActionStatus(STATUS_SIGNING);
     setTrustlineError(null);
     try {
-      await buildAndSubmitChangeTrust(fromAddress, "USDC", USDC_ISSUERS[network], network);
-      setTrustlineActionStatus("idle");
+      await buildAndSubmitChangeTrust(fromAddress, ASSET_USDC, USDC_ISSUERS[network], network);
+      setTrustlineActionStatus(STATUS_IDLE);
       // Re-fetch so trustlineStatus recomputes to "has"
       const info = await loadAccountInfo(fromAddress, network);
       setAccountExists(info.exists);
       setAllBalances(info.balances);
     } catch (e: unknown) {
       setTrustlineError(e instanceof Error ? e.message : "Failed to add trustline");
-      setTrustlineActionStatus("error");
+      setTrustlineActionStatus(STATUS_ERROR);
     }
   };
 
   const handleReset = () => {
     pollActiveRef.current = false;
     if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
-    setStep("form");
-    setTxStatus("idle");
+    setStep(STEP_FORM);
+    setTxStatus(STATUS_IDLE);
     setTxHash(null);
     setTxError(null);
     setPollStatus(null);
     setPollTimedOut(false);
-    setTrustlineActionStatus("idle");
+    setTrustlineActionStatus(STATUS_IDLE);
     setTrustlineError(null);
   };
 
@@ -241,7 +268,7 @@ export default function BridgePage() {
                       }}
                       placeholder={isConnected ? address! : "GABC...DEF or connect wallet"}
                       className="w-full pl-10 pr-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm font-mono focus:outline-none focus:border-[var(--primary)] transition-colors"
-                      disabled={txStatus !== "idle"}
+                      disabled={txStatus !== STATUS_IDLE}
                     />
                   </div>
                   {!validFrom && fromAddress && (
@@ -249,7 +276,7 @@ export default function BridgePage() {
                   )}
                   {accountExists === false && (
                     <p className="text-xs text-[var(--error)] mt-1">
-                      Account not found on the {network === "PUBLIC" ? "Mainnet" : "Testnet"} network. It needs to be funded first.
+                      Account not found on the {network === NETWORK_PUBLIC ? NETWORK_DISPLAY[NETWORK_PUBLIC] : NETWORK_DISPLAY[NETWORK_TESTNET]} network. It needs to be funded first.
                     </p>
                   )}
                   {isConnected && (
@@ -262,7 +289,7 @@ export default function BridgePage() {
                   )}
                   {sourceBalance !== null && (
                     <p className="text-xs text-[var(--text-muted)] mt-1">
-                      Balance: {parseFloat(sourceBalance).toFixed(2)} XLM
+                      Balance: {parseFloat(sourceBalance).toFixed(XLM_DISPLAY_DECIMALS)} {ASSET_XLM}
                     </p>
                   )}
                 </div>
@@ -284,12 +311,12 @@ export default function BridgePage() {
                       onChange={(e) => setToAddress(e.target.value)}
                       placeholder="CABC...DEF"
                       className="w-full pl-10 pr-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm font-mono focus:outline-none focus:border-[var(--primary)] transition-colors"
-                      disabled={txStatus !== "idle"}
+                      disabled={txStatus !== STATUS_IDLE}
                     />
                   </div>
                   {!validTo && toAddress && (
                     <p className="text-xs text-[var(--error)] mt-1">
-                      Invalid C-address (must start with C and be 56 characters)
+                      Invalid C-address (must start with C and be {STELLAR_ADDRESS_LENGTH} characters)
                     </p>
                   )}
                 </div>
@@ -312,10 +339,10 @@ export default function BridgePage() {
                       value={asset}
                       onChange={(e) => setAsset(e.target.value)}
                       className="px-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors"
-                      disabled={txStatus !== "idle"}
+                      disabled={txStatus !== STATUS_IDLE}
                     >
-                      <option>XLM</option>
-                      <option>USDC</option>
+                      <option>{ASSET_XLM}</option>
+                      <option>{ASSET_USDC}</option>
                     </select>
                   </div>
                   {balanceError && (
@@ -324,7 +351,7 @@ export default function BridgePage() {
                 </div>
 
                 {/* USDC trustline warning */}
-                {trustlineStatus === "missing" && (
+                {trustlineStatus === STATUS_MISSING && (
                   <div className="p-4 rounded-lg bg-amber-500/10 border border-amber-500/20">
                     <div className="flex items-start gap-3 mb-3">
                       <AlertTriangle className="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" />
@@ -340,10 +367,10 @@ export default function BridgePage() {
                     )}
                     <button
                       onClick={handleAddTrustline}
-                      disabled={trustlineActionStatus === "signing"}
+                      disabled={trustlineActionStatus === STATUS_SIGNING}
                       className="flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--primary)] text-white text-sm font-medium hover:bg-[var(--primary)]/90 transition-colors disabled:opacity-50"
                     >
-                      {trustlineActionStatus === "signing" ? (
+                      {trustlineActionStatus === STATUS_SIGNING ? (
                         <>
                           <Loader2 className="w-3 h-3 animate-spin" />
                           Adding Trustline…
@@ -355,7 +382,7 @@ export default function BridgePage() {
                   </div>
                 )}
 
-                {trustlineStatus === "has" && asset === "USDC" && (
+                {trustlineStatus === STATUS_HAS && asset === ASSET_USDC && (
                   <div className="flex items-center gap-2 p-3 rounded-lg bg-[var(--success)]/10 border border-[var(--success)]/20">
                     <Check className="w-4 h-4 text-[var(--success)]" />
                     <p className="text-xs text-[var(--success)]">USDC trustline established</p>
@@ -373,7 +400,7 @@ export default function BridgePage() {
               </div>
             )}
 
-            {step === "review" && (
+            {step === STEP_REVIEW && (
               <div className="space-y-6">
                 <h3 className="font-semibold text-lg">Review Transaction</h3>
 
@@ -392,11 +419,11 @@ export default function BridgePage() {
                   </div>
                   <div className="flex justify-between items-center p-4 rounded-lg bg-[var(--surface-2)]">
                     <span className="text-sm text-[var(--text-muted)]">Network</span>
-                    <span className="text-sm">{network === "PUBLIC" ? "Mainnet" : "Testnet"}</span>
+                    <span className="text-sm">{network === NETWORK_PUBLIC ? NETWORK_DISPLAY[NETWORK_PUBLIC] : NETWORK_DISPLAY[NETWORK_TESTNET]}</span>
                   </div>
                   <div className="flex justify-between items-center p-4 rounded-lg bg-[var(--surface-2)]">
                     <span className="text-sm text-[var(--text-muted)]">Fee</span>
-                    <span className="text-sm">~0.00001 XLM</span>
+                    <span className="text-sm">~{XLM_RESERVE_BUFFER} {ASSET_XLM}</span>
                   </div>
                 </div>
 
@@ -413,20 +440,20 @@ export default function BridgePage() {
                 <div className="flex gap-3">
                   <button
                     onClick={handleReset}
-                    disabled={txStatus === "signing" || txStatus === "submitting"}
+                    disabled={txStatus === STATUS_SIGNING || txStatus === STATUS_SUBMITTING}
                     className="flex-1 px-6 py-3 rounded-xl border border-[var(--border)] text-[var(--foreground)] font-medium hover:bg-[var(--surface-2)] transition-colors disabled:opacity-50"
                   >
                     Edit
                   </button>
                   <button
                     onClick={handleConfirm}
-                    disabled={txStatus === "signing" || txStatus === "submitting"}
+                    disabled={txStatus === STATUS_SIGNING || txStatus === STATUS_SUBMITTING}
                     className="flex-1 flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-[var(--primary)] text-white font-medium hover:bg-[var(--primary)]/90 transition-colors disabled:opacity-50"
                   >
-                    {txStatus === "signing" || txStatus === "submitting" ? (
+                    {txStatus === STATUS_SIGNING || txStatus === STATUS_SUBMITTING ? (
                       <>
                         <Loader2 className="w-4 h-4 animate-spin" />
-                        {txStatus === "signing" ? "Signing…" : "Submitting…"}
+                        {txStatus === STATUS_SIGNING ? "Signing…" : "Submitting…"}
                       </>
                     ) : (
                       <>
@@ -439,9 +466,9 @@ export default function BridgePage() {
               </div>
             )}
 
-            {step === "confirm" && txStatus === "success" && (
+            {step === STEP_CONFIRM && txStatus === STATUS_SUCCESS && (
               <div className="text-center py-12">
-                {pollStatus === "confirmed" ? (
+                {pollStatus === STATUS_CONFIRMED ? (
                   <>
                     <div className="w-16 h-16 rounded-full bg-[var(--success)]/10 flex items-center justify-center mx-auto mb-4">
                       <Check className="w-8 h-8 text-[var(--success)]" />
@@ -451,7 +478,7 @@ export default function BridgePage() {
                       Your transaction has been confirmed on the Stellar network.
                     </p>
                   </>
-                ) : pollStatus === "failed" ? (
+                ) : pollStatus === STATUS_FAILED ? (
                   <>
                     <div className="w-16 h-16 rounded-full bg-[var(--error)]/10 flex items-center justify-center mx-auto mb-4">
                       <XCircle className="w-8 h-8 text-[var(--error)]" />
@@ -496,7 +523,7 @@ export default function BridgePage() {
               </div>
             )}
 
-            {step === "confirm" && txStatus === "error" && (
+            {step === STEP_CONFIRM && txStatus === STATUS_ERROR && (
               <div className="text-center py-12">
                 <div className="w-16 h-16 rounded-full bg-[var(--error)]/10 flex items-center justify-center mx-auto mb-4">
                   <AlertCircle className="w-8 h-8 text-[var(--error)]" />
@@ -504,7 +531,7 @@ export default function BridgePage() {
                 <h3 className="text-lg font-semibold mb-2">Transaction Failed</h3>
                 <p className="text-sm text-[var(--text-muted)] mb-6">{txError || "An unexpected error occurred"}</p>
                 <button
-                  onClick={() => { setStep("review"); setTxStatus("idle"); setTxError(null); }}
+                  onClick={() => { setStep(STEP_REVIEW); setTxStatus(STATUS_IDLE); setTxError(null); }}
                   className="px-6 py-3 rounded-xl bg-[var(--primary)] text-white font-medium hover:bg-[var(--primary)]/90 transition-colors"
                 >
                   Try Again

--- a/src/app/cex/page.tsx
+++ b/src/app/cex/page.tsx
@@ -3,19 +3,18 @@
 import { useState } from "react";
 import { Building2, Copy, Check, ExternalLink, Wallet, Info } from "lucide-react";
 import { CEX_LIST, DEFAULT_BRIDGE_ADDRESS, DEFAULT_BRIDGE_MEMO } from "@/lib/types";
-
-const networks = ["Stellar", "Polygon", "Ethereum"];
+import { CEX_NETWORKS, CEX_NETWORK_STELLAR, COPY_FEEDBACK_MS } from "@/lib/constants";
 
 export default function CexPage() {
   const [selectedCex, setSelectedCex] = useState(CEX_LIST[0]);
-  const [selectedNetwork, setSelectedNetwork] = useState("Stellar");
+  const [selectedNetwork, setSelectedNetwork] = useState<string>(CEX_NETWORK_STELLAR);
   const [cAddress, setCAddress] = useState("");
   const [copiedField, setCopiedField] = useState<string | null>(null);
 
   const handleCopy = (text: string, field: string) => {
     navigator.clipboard.writeText(text);
     setCopiedField(field);
-    setTimeout(() => setCopiedField(null), 2000);
+    setTimeout(() => setCopiedField(null), COPY_FEEDBACK_MS);
   };
 
   const withdrawalUrl = selectedCex.withdrawalUrl;
@@ -55,7 +54,7 @@ export default function CexPage() {
           <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-6">
             <h3 className="font-semibold mb-4">2. Choose Withdrawal Network</h3>
             <div className="flex flex-wrap gap-2">
-              {networks.map((net) => (
+              {CEX_NETWORKS.map((net) => (
                 <button
                   key={net}
                   onClick={() => setSelectedNetwork(net)}
@@ -127,7 +126,7 @@ export default function CexPage() {
                 </div>
               )}
 
-              {selectedNetwork === "Stellar" && (
+              {selectedNetwork === CEX_NETWORK_STELLAR && (
                 <div>
                   <label className="block text-xs text-[var(--text-muted)] mb-1">Memo (Required for Stellar)</label>
                   <div className="flex items-center gap-2">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,6 +8,18 @@ import Link from "next/link";
 import { getAccountBalances, fetchRecentTransactions, getExplorerUrl } from "@/lib/stellar";
 import type { BridgeTransaction } from "@/lib/types";
 import { BRIDGE_CONTRACT_ID } from "@/lib/types";
+import {
+  ASSET_XLM,
+  NETWORK_DISPLAY,
+  DEFAULT_TX_LIMIT,
+  DASHBOARD_REFRESH_MS,
+  COPY_FEEDBACK_MS,
+  XLM_DISPLAY_DECIMALS,
+  ASSET_DISPLAY_DECIMALS,
+  STATUS_CONFIRMED,
+  STATUS_PENDING,
+  ENV_BRIDGE_CONTRACT_ID,
+} from "@/lib/constants";
 
 export default function DashboardPage() {
   const { isConnected, address, network, connect } = useWallet();
@@ -26,7 +38,7 @@ export default function DashboardPage() {
       try {
         const [balResult, txResult] = await Promise.all([
           getAccountBalances(address, network),
-          fetchRecentTransactions(address, network, 10),
+          fetchRecentTransactions(address, network, DEFAULT_TX_LIMIT),
         ]);
         setBalance(balResult.total);
         setAllBalances(balResult.balances);
@@ -38,18 +50,18 @@ export default function DashboardPage() {
       }
     };
     fetchData();
-    const interval = setInterval(fetchData, 30000);
+    const interval = setInterval(fetchData, DASHBOARD_REFRESH_MS);
     return () => clearInterval(interval);
   }, [isConnected, address, network]);
 
-  const confirmedCount = transactions.filter((t) => t.status === "confirmed").length;
-  const pendingCount = transactions.filter((t) => t.status === "pending").length;
+  const confirmedCount = transactions.filter((t) => t.status === STATUS_CONFIRMED).length;
+  const pendingCount = transactions.filter((t) => t.status === STATUS_PENDING).length;
 
   const handleCopy = () => {
     if (!address) return;
     navigator.clipboard.writeText(address);
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
   };
 
   if (!isConnected) {
@@ -95,7 +107,7 @@ export default function DashboardPage() {
         <div className="mb-6 p-3 rounded-lg bg-blue-500/10 border border-blue-500/20 text-sm text-blue-400 flex items-center gap-2">
           <span className="font-medium">Info:</span>
           Bridge contract not configured — bridge transactions will use direct payment.
-          Set <code className="font-mono text-xs">NEXT_PUBLIC_BRIDGE_CONTRACT_ID</code> to enable the smart contract.
+          Set <code className="font-mono text-xs">{ENV_BRIDGE_CONTRACT_ID}</code> to enable the smart contract.
         </div>
       )}
 
@@ -114,7 +126,7 @@ export default function DashboardPage() {
             </button>
           </div>
           <div className="text-xs text-[var(--text-muted)] mt-1">
-            {network === "PUBLIC" ? "Mainnet" : "Testnet"}
+            {NETWORK_DISPLAY[network]}
             {address && (
               <a
                 href={getExplorerUrl(network, "account", address)}
@@ -130,7 +142,7 @@ export default function DashboardPage() {
         </div>
 
         <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5">
-          <div className="text-xs text-[var(--text-muted)] mb-1">XLM Balance</div>
+          <div className="text-xs text-[var(--text-muted)] mb-1">{ASSET_XLM} Balance</div>
           {loading ? (
             <div className="flex items-center gap-2">
               <Loader2 className="w-4 h-4 animate-spin text-[var(--text-muted)]" />
@@ -139,9 +151,9 @@ export default function DashboardPage() {
           ) : (
             <>
               <div className="text-2xl font-bold mb-1">
-                {balance !== null ? parseFloat(balance).toFixed(2) : "—"}
+                {balance !== null ? parseFloat(balance).toFixed(XLM_DISPLAY_DECIMALS) : "—"}
               </div>
-              <div className="text-xs text-[var(--text-muted)]">XLM</div>
+              <div className="text-xs text-[var(--text-muted)]">{ASSET_XLM}</div>
             </>
           )}
         </div>
@@ -172,7 +184,7 @@ export default function DashboardPage() {
               <div key={b.asset} className="flex justify-between items-center py-2 first:pt-0 last:pb-0">
                 <span className="text-sm text-[var(--text-muted)]">{b.asset}</span>
                 <span className="text-sm font-mono">
-                  {parseFloat(b.amount).toFixed(b.asset === "XLM" ? 2 : 6)}
+                  {parseFloat(b.amount).toFixed(b.asset === ASSET_XLM ? XLM_DISPLAY_DECIMALS : ASSET_DISPLAY_DECIMALS)}
                 </span>
               </div>
             ))}

--- a/src/app/onramp/page.tsx
+++ b/src/app/onramp/page.tsx
@@ -3,13 +3,33 @@
 import { useState } from "react";
 import { CreditCard, Wallet, ExternalLink, ArrowRight, Check, DollarSign, AlertCircle } from "lucide-react";
 import { isValidStellarAddress, isCAddress } from "@/lib/stellar";
+import {
+  STELLAR_ADDRESS_LENGTH,
+  PROVIDER_MOONPAY,
+  PROVIDER_TRANSAK,
+  WALLET_CHAIN_STELLAR,
+  DEFAULT_CRYPTO_CURRENCY,
+  MOONPAY_FEE_RATE,
+  TRANSAK_FEE_RATE,
+  BASE_RECEIVE_MULTIPLIER,
+  MOONPAY_RECEIVE_MULTIPLIER,
+  TRANSAK_RECEIVE_MULTIPLIER,
+  FIAT_DISPLAY_DECIMALS,
+  MOONPAY_BASE_URL,
+  TRANSAK_BASE_URL,
+  REDIRECT_DELAY_MS,
+  ENV_MOONPAY_API_KEY,
+  ENV_TRANSAK_API_KEY,
+  STEP_FORM,
+  STEP_REDIRECT,
+} from "@/lib/constants";
 
 const MOONPAY_API_KEY = process.env.NEXT_PUBLIC_MOONPAY_API_KEY || "";
 const TRANSAK_API_KEY = process.env.NEXT_PUBLIC_TRANSAK_API_KEY || "";
 
 const providers = [
   {
-    id: "moonpay",
+    id: PROVIDER_MOONPAY,
     name: "Moonpay",
     description: "Buy with credit/debit card",
     fee: "4.5%",
@@ -17,10 +37,10 @@ const providers = [
     currencies: ["USD", "EUR", "GBP"],
     supported: true,
     apiKey: MOONPAY_API_KEY,
-    baseUrl: "https://buy.moonpay.com",
+    baseUrl: MOONPAY_BASE_URL,
   },
   {
-    id: "transak",
+    id: PROVIDER_TRANSAK,
     name: "Transak",
     description: "Buy with card, Apple Pay, Google Pay",
     fee: "5%",
@@ -28,15 +48,15 @@ const providers = [
     currencies: ["USD", "EUR", "GBP", "INR"],
     supported: true,
     apiKey: TRANSAK_API_KEY,
-    baseUrl: "https://global.transak.com",
+    baseUrl: TRANSAK_BASE_URL,
   },
 ];
 
 export default function OnrampPage() {
   const [cAddress, setCAddress] = useState("");
   const [fiatAmount, setFiatAmount] = useState("");
-  const [selectedProvider, setSelectedProvider] = useState("moonpay");
-  const [step, setStep] = useState<"form" | "redirect">("form");
+  const [selectedProvider, setSelectedProvider] = useState<string>(PROVIDER_MOONPAY);
+  const [step, setStep] = useState<"form" | "redirect">(STEP_FORM);
   const [error, setError] = useState<string | null>(null);
 
   const validAddress = !cAddress || (isValidStellarAddress(cAddress) && isCAddress(cAddress));
@@ -51,17 +71,17 @@ export default function OnrampPage() {
     if (!provider) return;
 
     if (!provider.apiKey) {
-      setError(`${provider.name} API key is not configured. Set NEXT_PUBLIC_${provider.id === "moonpay" ? "MOONPAY" : "TRANSAK"}_API_KEY in your environment.`);
+      setError(`${provider.name} API key is not configured. Set ${provider.id === PROVIDER_MOONPAY ? ENV_MOONPAY_API_KEY : ENV_TRANSAK_API_KEY} in your environment.`);
       return;
     }
 
-    setStep("redirect");
+    setStep(STEP_REDIRECT);
 
     const params = new URLSearchParams({
       apiKey: provider.apiKey,
       walletAddress: cAddress,
-      walletChain: "Stellar",
-      defaultCryptoCurrency: "USDC",
+      walletChain: WALLET_CHAIN_STELLAR,
+      defaultCryptoCurrency: DEFAULT_CRYPTO_CURRENCY,
       defaultFiatAmount: fiatAmount,
     });
 
@@ -69,7 +89,7 @@ export default function OnrampPage() {
 
     setTimeout(() => {
       window.open(url, "_blank", "noopener,noreferrer");
-    }, 1500);
+    }, REDIRECT_DELAY_MS);
   };
 
   const provider = providers.find((p) => p.id === selectedProvider);
@@ -98,7 +118,7 @@ export default function OnrampPage() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <div className="lg:col-span-2">
           <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-6">
-            {step === "form" && (
+            {step === STEP_FORM && (
               <div className="space-y-6">
                 <div>
                   <label className="block text-sm font-medium mb-3">Select Provider</label>
@@ -143,7 +163,7 @@ export default function OnrampPage() {
                     />
                   </div>
                   {!validAddress && cAddress && (
-                    <p className="text-xs text-[var(--error)] mt-1">Invalid C-address (must start with C, 56 characters)</p>
+                    <p className="text-xs text-[var(--error)] mt-1">Invalid C-address (must start with C, {STELLAR_ADDRESS_LENGTH} characters)</p>
                   )}
                 </div>
 
@@ -173,14 +193,14 @@ export default function OnrampPage() {
                   <div className="flex justify-between text-sm mt-1">
                     <span className="text-[var(--text-muted)]">Fee ({provider?.fee})</span>
                     <span>
-                      -${fiatAmount ? (Number(fiatAmount) * (selectedProvider === "moonpay" ? 0.045 : 0.05)).toFixed(2) : "0"}
+                      -${fiatAmount ? (Number(fiatAmount) * (selectedProvider === PROVIDER_MOONPAY ? MOONPAY_FEE_RATE : TRANSAK_FEE_RATE)).toFixed(FIAT_DISPLAY_DECIMALS) : "0"}
                     </span>
                   </div>
                   <div className="flex justify-between text-sm mt-1">
                     <span className="text-[var(--text-muted)]">Est. receive</span>
                     <span className="font-semibold">
                       {fiatAmount && validAmount
-                        ? `~${(Number(fiatAmount) * 0.95 * (selectedProvider === "moonpay" ? 1 : 0.95)).toFixed(2)} USDC`
+                        ? `~${(Number(fiatAmount) * BASE_RECEIVE_MULTIPLIER * (selectedProvider === PROVIDER_MOONPAY ? MOONPAY_RECEIVE_MULTIPLIER : TRANSAK_RECEIVE_MULTIPLIER)).toFixed(FIAT_DISPLAY_DECIMALS)} USDC`
                         : "—"}
                     </span>
                   </div>
@@ -204,7 +224,7 @@ export default function OnrampPage() {
               </div>
             )}
 
-            {step === "redirect" && (
+            {step === STEP_REDIRECT && (
               <div className="text-center py-12">
                 <div className="w-16 h-16 rounded-full bg-[var(--primary)]/10 flex items-center justify-center mx-auto mb-4">
                   <ExternalLink className="w-8 h-8 text-[var(--primary-light)]" />
@@ -214,7 +234,7 @@ export default function OnrampPage() {
                   You will be redirected to complete your purchase. Funds will be sent to your C-address.
                 </p>
                 <button
-                  onClick={() => setStep("form")}
+                  onClick={() => setStep(STEP_FORM)}
                   className="text-sm text-[var(--primary-light)] hover:underline"
                 >
                   Go back

--- a/src/components/transaction-history.tsx
+++ b/src/components/transaction-history.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeftRight, CreditCard, Building2, ExternalLink, Loader2 } from "lucide-react";
 import type { BridgeTransaction as BridgeTransactionData } from "@/lib/types";
 import { getExplorerUrl } from "@/lib/stellar";
+import { EXPLORER_BASE_URLS } from "@/lib/constants";
 
 const typeConfig: Record<string, { icon: typeof ArrowLeftRight; label: string; color: string }> = {
   "g-to-c": { icon: ArrowLeftRight, label: "G → C Bridge", color: "text-[var(--primary-light)]" },
@@ -79,7 +80,7 @@ export default function TransactionHistory({ transactions, loading, network }: P
       )}
       <div className="p-4 border-t border-[var(--border)]">
         <a
-          href={`https://stellar.expert/explorer/${network === "PUBLIC" ? "public" : "testnet"}`}
+          href={EXPLORER_BASE_URLS[network]}
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center justify-center gap-1 text-sm text-[var(--text-muted)] hover:text-[var(--foreground)] transition-colors"

--- a/src/components/wallet-provider.tsx
+++ b/src/components/wallet-provider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react";
 import { connectWallet, checkConnection, getWalletAddress, getCurrentNetwork } from "@/lib/stellar";
+import { WALLET_INITIAL_DELAY_MS, WALLET_POLL_INTERVAL_MS, DEFAULT_NETWORK } from "@/lib/constants";
 
 interface WalletContextType {
   address: string | null;
@@ -16,7 +17,7 @@ interface WalletContextType {
 const WalletContext = createContext<WalletContextType>({
   address: null,
   publicKey: null,
-  network: "TESTNET",
+  network: DEFAULT_NETWORK,
   isConnected: false,
   isConnecting: false,
   connect: async () => {},
@@ -25,7 +26,7 @@ const WalletContext = createContext<WalletContextType>({
 
 export function WalletProvider({ children }: { children: ReactNode }) {
   const [address, setAddress] = useState<string | null>(null);
-  const [network, setNetwork] = useState<"PUBLIC" | "TESTNET">("TESTNET");
+  const [network, setNetwork] = useState<"PUBLIC" | "TESTNET">(DEFAULT_NETWORK);
   const [isConnecting, setIsConnecting] = useState(false);
 
   const updateConnection = useCallback(async () => {
@@ -41,8 +42,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    const timer = setTimeout(updateConnection, 0);
-    const interval = setInterval(updateConnection, 3000);
+    const timer = setTimeout(updateConnection, WALLET_INITIAL_DELAY_MS);
+    const interval = setInterval(updateConnection, WALLET_POLL_INTERVAL_MS);
     return () => { clearTimeout(timer); clearInterval(interval); };
   }, [updateConnection]);
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,128 @@
+/** Stellar asset codes used throughout the application */
+export const ASSET_XLM = "XLM" as const;
+export const ASSET_USDC = "USDC" as const;
+
+/** Horizon API asset_type value for native XLM */
+export const NATIVE_ASSET_TYPE = "native" as const;
+
+/** Fallback label when an asset code cannot be determined */
+export const UNKNOWN_ASSET = "unknown" as const;
+
+/** Regex matching valid Stellar G- and C-addresses (56-char base-32) */
+export const STELLAR_ADDRESS_REGEX = /^[G|C][A-Z0-9]{55}$/;
+
+/** Expected length of a Stellar public key (G or C address) */
+export const STELLAR_ADDRESS_LENGTH = 56;
+
+/** Named network identifiers */
+export const NETWORK_PUBLIC = "PUBLIC" as const;
+export const NETWORK_TESTNET = "TESTNET" as const;
+
+/** Human-readable labels for each network */
+export const NETWORK_DISPLAY: Record<string, string> = {
+  [NETWORK_PUBLIC]: "Mainnet",
+  [NETWORK_TESTNET]: "Testnet",
+};
+
+/** Default network when none is configured */
+export const DEFAULT_NETWORK = NETWORK_TESTNET;
+
+/** CEX withdrawal network identifiers */
+export const CEX_NETWORK_STELLAR = "Stellar" as const;
+export const CEX_NETWORKS = ["Stellar", "Polygon", "Ethereum"] as const;
+
+/** Time intervals in milliseconds */
+export const WALLET_INITIAL_DELAY_MS = 0;
+export const WALLET_POLL_INTERVAL_MS = 3000;
+export const DASHBOARD_REFRESH_MS = 30000;
+export const TX_POLL_INTERVAL_MS = 5000;
+export const COPY_FEEDBACK_MS = 2000;
+export const REDIRECT_DELAY_MS = 1500;
+
+/** Maximum polling attempts before giving up on transaction confirmation */
+export const TX_MAX_ATTEMPTS = 24;
+
+/** Stellar transaction timebound (seconds from build) */
+export const STELLAR_TX_TIMEOUT_SECONDS = 30;
+
+/** Default limit for fetching recent payments */
+export const DEFAULT_TX_LIMIT = 10;
+
+/** Minimum XLM reserve buffer used for balance validation */
+export const XLM_RESERVE_BUFFER = 0.00001;
+
+/** Base-2 reserve required for a new Stellar account (in XLM) */
+export const ACCOUNT_MIN_BALANCE = "1.0";
+
+/** Fallback zero balance string */
+export const BALANCE_INITIAL = "0";
+
+/** Onramp provider fee rates (as decimal multipliers) */
+export const MOONPAY_FEE_RATE = 0.045;
+export const TRANSAK_FEE_RATE = 0.05;
+
+/** Multipliers applied after fee deduction to compute estimated receive */
+export const BASE_RECEIVE_MULTIPLIER = 0.95;
+export const MOONPAY_RECEIVE_MULTIPLIER = 1;
+export const TRANSAK_RECEIVE_MULTIPLIER = 0.95;
+
+/** Onramp provider identifiers */
+export const PROVIDER_MOONPAY = "moonpay" as const;
+export const PROVIDER_TRANSAK = "transak" as const;
+
+/** Number of decimal places for display formatting */
+export const XLM_DISPLAY_DECIMALS = 2;
+export const XLM_PRECISE_DECIMALS = 7;
+export const ASSET_DISPLAY_DECIMALS = 6;
+export const FIAT_DISPLAY_DECIMALS = 2;
+
+/** Stellar.explorer base URLs per network */
+export const EXPLORER_BASE_URLS: Record<string, string> = {
+  [NETWORK_PUBLIC]: "https://stellar.expert/explorer/public",
+  [NETWORK_TESTNET]: "https://stellar.expert/explorer/testnet",
+};
+
+/** Onramp provider base URLs */
+export const MOONPAY_BASE_URL = "https://buy.moonpay.com";
+export const TRANSAK_BASE_URL = "https://global.transak.com";
+
+/** Environment variable keys used for configuration */
+export const ENV_BRIDGE_CONTRACT_ID = "NEXT_PUBLIC_BRIDGE_CONTRACT_ID";
+export const ENV_MOONPAY_API_KEY = "NEXT_PUBLIC_MOONPAY_API_KEY";
+export const ENV_TRANSAK_API_KEY = "NEXT_PUBLIC_TRANSAK_API_KEY";
+export const ENV_STELLAR_NETWORK = "NEXT_PUBLIC_STELLAR_NETWORK";
+
+/** Shared status strings used across components */
+export const STATUS_PENDING = "pending" as const;
+export const STATUS_CONFIRMED = "confirmed" as const;
+export const STATUS_FAILED = "failed" as const;
+export const STATUS_IDLE = "idle" as const;
+export const STATUS_SIGNING = "signing" as const;
+export const STATUS_SUBMITTING = "submitting" as const;
+export const STATUS_SUCCESS = "success" as const;
+export const STATUS_ERROR = "error" as const;
+export const STATUS_CONFIGURED = "configured" as const;
+export const STATUS_MISSING = "missing" as const;
+export const STATUS_UNKNOWN = "unknown" as const;
+export const STATUS_HAS = "has" as const;
+
+/** Step labels for multi-step forms */
+export const STEP_FORM = "form" as const;
+export const STEP_REVIEW = "review" as const;
+export const STEP_CONFIRM = "confirm" as const;
+export const STEP_REDIRECT = "redirect" as const;
+
+/** Bridge transaction type identifiers */
+export const TX_TYPE_G_TO_C = "g-to-c" as const;
+export const TX_TYPE_FIAT = "fiat" as const;
+export const TX_TYPE_CEX = "cex" as const;
+
+/** Onramp widget parameters */
+export const WALLET_CHAIN_STELLAR = "Stellar" as const;
+export const DEFAULT_CRYPTO_CURRENCY = "USDC" as const;
+
+/** USDC issuer addresses for each Stellar network */
+export const USDC_ISSUERS: Record<string, string> = {
+  PUBLIC: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+  TESTNET: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+};

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -21,6 +21,27 @@ import {
   type AccountBalances,
   type BridgeTransaction,
 } from "./types";
+import {
+  ASSET_XLM,
+  NATIVE_ASSET_TYPE,
+  UNKNOWN_ASSET,
+  STELLAR_ADDRESS_REGEX,
+  STELLAR_ADDRESS_LENGTH,
+  NETWORK_PUBLIC,
+  DEFAULT_NETWORK,
+  DEFAULT_TX_LIMIT,
+  STELLAR_TX_TIMEOUT_SECONDS,
+  ACCOUNT_MIN_BALANCE,
+  EXPLORER_BASE_URLS,
+  STATUS_CONFIRMED,
+  STATUS_FAILED,
+  STATUS_PENDING,
+  BALANCE_INITIAL,
+  TX_TYPE_G_TO_C,
+  ENV_BRIDGE_CONTRACT_ID,
+  ENV_MOONPAY_API_KEY,
+  ENV_TRANSAK_API_KEY,
+} from "./constants";
 
 export type { BridgeTransaction as BridgeTransactionData } from "./types";
 export type { PaymentResult, AccountBalances } from "./types";
@@ -34,7 +55,7 @@ export function getSorobanRpcServer(network: "PUBLIC" | "TESTNET"): rpc.Server {
 }
 
 export function getNetworkPassphrase(network: "PUBLIC" | "TESTNET"): string {
-  return network === "PUBLIC" ? Networks.PUBLIC : Networks.TESTNET;
+  return network === NETWORK_PUBLIC ? Networks.PUBLIC : Networks.TESTNET;
 }
 
 export async function connectWallet(): Promise<string | null> {
@@ -74,32 +95,32 @@ export async function getCurrentNetwork(): Promise<"PUBLIC" | "TESTNET"> {
     const result = await getNetwork();
     return result.network === Networks.PUBLIC ? "PUBLIC" : "TESTNET";
   } catch {
-    return "TESTNET";
+    return DEFAULT_NETWORK;
   }
 }
 
 export function isValidStellarAddress(address: string): boolean {
-  return /^[G|C][A-Z0-9]{55}$/.test(address);
+  return STELLAR_ADDRESS_REGEX.test(address);
 }
 
 export function isCAddress(address: string): boolean {
-  return address.startsWith("C") && address.length === 56;
+  return address.startsWith("C") && address.length === STELLAR_ADDRESS_LENGTH;
 }
 
 export function isGAddress(address: string): boolean {
-  return address.startsWith("G") && address.length === 56;
+  return address.startsWith("G") && address.length === STELLAR_ADDRESS_LENGTH;
 }
 
 export function validateEnvironment(): string[] {
   const warnings: string[] = [];
-  if (!process.env.NEXT_PUBLIC_BRIDGE_CONTRACT_ID) {
-    warnings.push("NEXT_PUBLIC_BRIDGE_CONTRACT_ID is not set; bridge will fall back to direct payment");
+  if (!process.env[ENV_BRIDGE_CONTRACT_ID]) {
+    warnings.push(`${ENV_BRIDGE_CONTRACT_ID} is not set; bridge will fall back to direct payment`);
   }
-  if (!process.env.NEXT_PUBLIC_MOONPAY_API_KEY) {
-    warnings.push("NEXT_PUBLIC_MOONPAY_API_KEY is not set; Moonpay onramp will be unavailable");
+  if (!process.env[ENV_MOONPAY_API_KEY]) {
+    warnings.push(`${ENV_MOONPAY_API_KEY} is not set; Moonpay onramp will be unavailable`);
   }
-  if (!process.env.NEXT_PUBLIC_TRANSAK_API_KEY) {
-    warnings.push("NEXT_PUBLIC_TRANSAK_API_KEY is not set; Transak onramp will be unavailable");
+  if (!process.env[ENV_TRANSAK_API_KEY]) {
+    warnings.push(`${ENV_TRANSAK_API_KEY} is not set; Transak onramp will be unavailable`);
   }
   return warnings;
 }
@@ -131,20 +152,20 @@ export async function getAccountBalances(
   try {
     const account = await server.loadAccount(address);
     const balances = (account.balances as HorizonBalance[]).map((b) => ({
-      asset: b.asset_type === "native" ? "XLM" : (b.asset_code || "unknown"),
+      asset: b.asset_type === NATIVE_ASSET_TYPE ? ASSET_XLM : (b.asset_code || UNKNOWN_ASSET),
       amount: b.balance,
     }));
-    const total = balances.find((b) => b.asset === "XLM")?.amount || "0";
+    const total = balances.find((b) => b.asset === ASSET_XLM)?.amount || BALANCE_INITIAL;
     return { total, balances };
   } catch {
-    return { total: "0", balances: [] };
+    return { total: BALANCE_INITIAL, balances: [] };
   }
 }
 
 export async function fetchRecentTransactions(
   address: string,
   network: "PUBLIC" | "TESTNET",
-  limit: number = 10
+  limit: number = DEFAULT_TX_LIMIT
 ): Promise<BridgeTransaction[]> {
   const server = getHorizonServer(network);
   try {
@@ -160,10 +181,10 @@ export async function fetchRecentTransactions(
       fromAddress: p.from || "",
       toAddress: p.to || "",
       amount: p.amount || "0",
-      asset: p.asset_type === "native" ? "XLM" : (p.asset_code || "XLM"),
-      status: p.transaction_successful ? "confirmed" as const : "failed" as const,
+      asset: p.asset_type === NATIVE_ASSET_TYPE ? ASSET_XLM : (p.asset_code || ASSET_XLM),
+      status: p.transaction_successful ? STATUS_CONFIRMED : STATUS_FAILED,
       timestamp: new Date(p.created_at || Date.now()).getTime(),
-      type: "g-to-c" as const,
+      type: TX_TYPE_G_TO_C,
       hash: p.transaction_hash,
     }));
   } catch {
@@ -207,7 +228,7 @@ export async function buildAndSubmitPayment(
         amount,
       })
     )
-    .setTimeout(30)
+    .setTimeout(STELLAR_TX_TIMEOUT_SECONDS)
     .build();
 
   const signedResult = await signTransaction(tx.toXDR(), {
@@ -256,7 +277,7 @@ export async function bridgeViaContract(
         amount,
       })
     )
-    .setTimeout(30)
+    .setTimeout(STELLAR_TX_TIMEOUT_SECONDS)
     .build();
 
   const unsignedXDR = tx.toXDR();
@@ -294,20 +315,12 @@ export function getExplorerUrl(
   type: "tx" | "account" | "contract",
   id: string
 ): string {
-  const base = network === "PUBLIC"
-    ? "https://stellar.expert/explorer/public"
-    : "https://stellar.expert/explorer/testnet";
-  return `${base}/${type}/${id}`;
+  return `${EXPLORER_BASE_URLS[network]}/${type}/${id}`;
 }
 
 export function getAccountMinimumBalance(): string {
-  return "1.0";
+  return ACCOUNT_MIN_BALANCE;
 }
-
-export const USDC_ISSUERS: Record<"PUBLIC" | "TESTNET", string> = {
-  PUBLIC: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-  TESTNET: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-};
 
 export interface AccountInfo {
   exists: boolean;
@@ -322,7 +335,7 @@ export async function loadAccountInfo(
   try {
     const account = await server.loadAccount(address);
     const balances = (account.balances as HorizonBalance[]).map((b) => ({
-      asset: b.asset_type === "native" ? "XLM" : (b.asset_code || "unknown"),
+      asset: b.asset_type === NATIVE_ASSET_TYPE ? ASSET_XLM : (b.asset_code || UNKNOWN_ASSET),
       amount: b.balance,
     }));
     return { exists: true, balances };
@@ -363,7 +376,7 @@ export async function buildAndSubmitChangeTrust(
     networkPassphrase: passphrase,
   })
     .addOperation(changeTrustOperation(assetCode, issuer))
-    .setTimeout(30)
+    .setTimeout(STELLAR_TX_TIMEOUT_SECONDS)
     .build();
 
   const signedResult = await signTransaction(tx.toXDR(), { networkPassphrase: passphrase });
@@ -383,11 +396,11 @@ export async function getTransactionStatus(
   const server = getHorizonServer(network);
   try {
     const tx = await server.transactions().transaction(hash).call();
-    return tx.successful ? "confirmed" : "failed";
+    return tx.successful ? STATUS_CONFIRMED : STATUS_FAILED;
   } catch (e: unknown) {
     const err = e as { response?: { status?: number } };
     if (err.response?.status === 404) {
-      return "pending";
+      return STATUS_PENDING;
     }
     throw e;
   }


### PR DESCRIPTION
Defined all asset codes, polling intervals, fee rates, and other magic values as named constants in src/lib/constants.ts with documented purpose for each constant.

Key changes:
- Asset codes (XLM, USDC) as const objects
- Polling intervals extracted into timing constants
- USDC issuer addresses moved to constants
- Address validation constants (regex, length)
- Provider fee rates and receive multipliers
- Display formatting constants (decimal places)
- Status strings, step labels, and transaction types
- Explorer URLs, provider URLs, env var names
- All inline values replaced throughout the codebase

Closes: #10