### PR TITLE
feat(frontend): implement soroban c-address format validation and che…

### DIFF
--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -17,6 +17,7 @@ import {
   buildAndSubmitChangeTrust,
   getTransactionStatus,
 } from "@/lib/stellar";
+import { validateCAddress } from "@/utils/validation";
 import {
   ASSET_XLM,
   ASSET_USDC,
@@ -232,7 +233,8 @@ export default function BridgePage() {
   // --- Validation ---
 
   const validFrom = !fromAddress || isValidStellarAddress(fromAddress);
-  const validTo = !toAddress || (isValidStellarAddress(toAddress) && isCAddress(toAddress));
+  const toAddressError = validateCAddress(toAddress);
+  const validTo = !toAddress || (!toAddressError && isCAddress(toAddress));
   const validAmount = !!amount && !isNaN(parseFloat(amount)) && parseFloat(amount) > 0;
 
   const canProceed =
@@ -446,7 +448,7 @@ export default function BridgePage() {
                   </div>
                   {!validTo && toAddress && (
                     <p className="text-xs text-[var(--error)] mt-1">
-                      Invalid C-address (must start with C and be {STELLAR_ADDRESS_LENGTH} characters)
+                      {toAddressError}
                     </p>
                   )}
                 </div>

--- a/src/app/cex/page.tsx
+++ b/src/app/cex/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Building2, Copy, Check, ExternalLink, Wallet, Info } from "lucide-react";
 import { CEX_LIST, DEFAULT_BRIDGE_ADDRESS, DEFAULT_BRIDGE_MEMO } from "@/lib/types";
 import { CEX_NETWORKS, CEX_NETWORK_STELLAR, COPY_FEEDBACK_MS } from "@/lib/constants";
+import { validateCAddress } from "@/utils/validation";
 
 export default function CexPage() {
   const [selectedCex, setSelectedCex] = useState(CEX_LIST[0]);
@@ -18,6 +19,7 @@ export default function CexPage() {
   };
 
   const withdrawalUrl = selectedCex.withdrawalUrl;
+  const cAddressError = validateCAddress(cAddress);
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -86,9 +88,12 @@ export default function CexPage() {
                 className="w-full pl-10 pr-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm font-mono focus:outline-none focus:border-[var(--primary)] transition-colors"
               />
             </div>
+            {cAddressError && cAddress && (
+              <p className="text-xs text-[var(--error)] mt-1">{cAddressError}</p>
+            )}
           </div>
 
-          {cAddress && (
+          {cAddress && !cAddressError && (
             <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-6">
               <h3 className="font-semibold mb-4">4. Verify Bridge Address Access</h3>
               <CEXAddressVerification

--- a/src/app/onramp/page.tsx
+++ b/src/app/onramp/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { CreditCard, Wallet, ExternalLink, ArrowRight, Check, DollarSign, AlertCircle } from "lucide-react";
 import { isValidStellarAddress, isCAddress } from "@/lib/stellar";
+import { validateCAddress } from "@/utils/validation";
 import {
   STELLAR_ADDRESS_LENGTH,
   PROVIDER_MOONPAY,
@@ -59,7 +60,8 @@ export default function OnrampPage() {
   const [step, setStep] = useState<"form" | "redirect">(STEP_FORM);
   const [error, setError] = useState<string | null>(null);
 
-  const validAddress = !cAddress || (isValidStellarAddress(cAddress) && isCAddress(cAddress));
+  const cAddressError = validateCAddress(cAddress);
+  const validAddress = !cAddress || (!cAddressError && isValidStellarAddress(cAddress) && isCAddress(cAddress));
   const validAmount = !fiatAmount || /^\d+(\.\d{1,2})?$/.test(fiatAmount);
   const canProceed = cAddress && fiatAmount && validAddress && validAmount;
 
@@ -163,7 +165,7 @@ export default function OnrampPage() {
                     />
                   </div>
                   {!validAddress && cAddress && (
-                    <p className="text-xs text-[var(--error)] mt-1">Invalid C-address (must start with C, {STELLAR_ADDRESS_LENGTH} characters)</p>
+                    <p className="text-xs text-[var(--error)] mt-1">{cAddressError}</p>
                   )}
                 </div>
 

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { validateCAddress } from "./validation";
+
+const VALID_C = "CD3PAUUC6WSXPQQM26UNI7ZBRQLOQSLOXYZPCYC32U4C2EDROJZM2MOL";
+const CORRUPT_CHECKSUM = "CD3PAUUC6WAXPQQM26UNI7ZBRQLOQSLOXYZPCYC32U4C2EDROJZM2MOL";
+const VALID_G = "GA5GHFQ2MX27ZRULWWRWAANVL7SSMDU6LF2A42QK52335UGPCJYWTCT7";
+
+describe("validateCAddress", () => {
+  it("returns null for a valid C-address", () => {
+    expect(validateCAddress(VALID_C)).toBeNull();
+  });
+
+  it("returns null for empty string when not required", () => {
+    expect(validateCAddress("")).toBeNull();
+  });
+
+  it("returns required error when blank and required=true", () => {
+    expect(validateCAddress("", true)).toBe("Contract ID is required.");
+  });
+
+  it("flags a valid G-address with the Account ID message", () => {
+    const error = validateCAddress(VALID_G);
+    expect(error).toBe(
+      "This is a Stellar Account ID. Please enter a Soroban Contract ID starting with 'C'."
+    );
+  });
+
+  it("flags a non-C/non-G prefix with the general format message", () => {
+    const error = validateCAddress("XABC123");
+    expect(error).toBe(
+      "Soroban Contract IDs must be exactly 56 characters long and start with 'C'."
+    );
+  });
+
+  it("flags a too-short C-prefix string with the general format message", () => {
+    const error = validateCAddress("CABC123");
+    expect(error).toBe(
+      "Soroban Contract IDs must be exactly 56 characters long and start with 'C'."
+    );
+  });
+
+  it("flags a too-long C-prefix string with the general format message", () => {
+    const error = validateCAddress("C" + "A".repeat(56));
+    expect(error).toBe(
+      "Soroban Contract IDs must be exactly 56 characters long and start with 'C'."
+    );
+  });
+
+  it("flags a 56-char C-address with corrupted checksum", () => {
+    expect(validateCAddress(CORRUPT_CHECKSUM)).toBe(
+      "Invalid Contract ID checksum. Check for typos or omitted characters."
+    );
+  });
+
+  it("flags a G-address with C prefix as bad checksum", () => {
+    const gAsC = "C" + VALID_G.slice(1);
+    expect(validateCAddress(gAsC)).toBe(
+      "Invalid Contract ID checksum. Check for typos or omitted characters."
+    );
+  });
+});

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,29 @@
+import { StrKey } from "@stellar/stellar-sdk";
+
+/**
+ * Validates a Soroban C-address.
+ * Returns null when valid, or a contextual error string.
+ * Returns a "required" error when address is blank (use for submitted forms).
+ */
+export function validateCAddress(address: string, required = false): string | null {
+  if (!address) {
+    return required ? "Contract ID is required." : null;
+  }
+
+  if (!address.startsWith("C")) {
+    if (address.startsWith("G") && StrKey.isValidEd25519PublicKey(address)) {
+      return "This is a Stellar Account ID. Please enter a Soroban Contract ID starting with 'C'.";
+    }
+    return "Soroban Contract IDs must be exactly 56 characters long and start with 'C'.";
+  }
+
+  if (address.length !== 56) {
+    return "Soroban Contract IDs must be exactly 56 characters long and start with 'C'.";
+  }
+
+  if (!StrKey.isValidContract(address)) {
+    return "Invalid Contract ID checksum. Check for typos or omitted characters.";
+  }
+
+  return null;
+}


### PR DESCRIPTION
Description
Closes #27
Overview
This PR repairs a critical gap in our onboarding entry fields where Soroban Smart Contract IDs ("C-addresses") were treated identically to standard Stellar Account Public Keys ("G-addresses"). By upgrading our validation engine to parse StrKey contract encodings explicitly, this change ensures the bridge interface correctly filters, checks, and validates incoming onboarding destinations before processing network interactions.

Changes
Branch: Tracked and pushed under feat/27-soroban-c-address-validation.

Validation Engine Upgrades (src/utils/validation.ts):

Integrated @stellar/stellar-sdk's StrKey.isValidContractId pipeline to strictly enforce base32 decoding compliance.

Added underlying CRC16 cryptographic checksum checks to catch typos or character omissions instantly.

UI Content Refactoring:

Implemented detailed conditional error feedback. If a user inputs a standard 'G' address, the system prompts them that a Soroban Contract ID is required, reducing friction during multi-chain onboarding.

Unit Testing Matrix Added (src/utils/validation.test.ts):

Seeded comprehensive success and failure vectors evaluating structural string lengths, prefix rules, and valid/invalid checksum arrays.

Architectural Properties Validated
Cryptographic Certainty: Eliminates the risk of clients broadcasting bridge payloads bound for un-executable or typo-mutilated contract addresses.

Separation of Concerns: Decouples structural string evaluation entirely into helper utility files for clean code reusability across different form sheets.

Verification & Testing Checklist
[x] Type Safety Verification: Confirmed full project compilation under native TypeScript specifications with zero type errors.

[x] Linter Compliance: Validated modified assets via npm run lint to clear workspace formatting requirements.

[x] Conventional Commit Integrity: Grouped modifications into an atomic conventional commit framework and pushed cleanly upstream.