### PR TITLE
feat: replace polling with event-driven updates (issue #12)

### DIFF
--- a/src/__tests__/use-dashboard-data.test.ts
+++ b/src/__tests__/use-dashboard-data.test.ts
@@ -1,0 +1,343 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/stellar", () => ({
+  getAccountBalances: vi.fn(),
+  fetchRecentTransactions: vi.fn(),
+  isCAddress: vi.fn(),
+  getSorobanAccountBalances: vi.fn(),
+}));
+
+vi.mock("@/lib/horizon-stream", () => ({
+  streamPayments: vi.fn(),
+  isStreamingSupported: vi.fn(),
+}));
+
+import {
+  getAccountBalances,
+  fetchRecentTransactions,
+  isCAddress,
+  getSorobanAccountBalances,
+} from "@/lib/stellar";
+import { streamPayments, isStreamingSupported } from "@/lib/horizon-stream";
+import { useDashboardData } from "@/lib/use-dashboard-data";
+import type { BridgeTransaction } from "@/lib/types";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const G_ADDRESS = "GAIUIQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5A";
+const C_ADDRESS = "CAIUIQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5A";
+
+const MOCK_BALANCES = {
+  total: "100",
+  balances: [{ asset: "XLM", amount: "100" }],
+};
+
+const MOCK_TX: BridgeTransaction = {
+  id: "tx1",
+  fromAddress: G_ADDRESS,
+  toAddress: C_ADDRESS,
+  amount: "10",
+  asset: "XLM",
+  status: "confirmed",
+  timestamp: Date.now(),
+  type: "g-to-c",
+  hash: "abc123",
+};
+
+function setupDefaultMocks() {
+  vi.mocked(isCAddress).mockReturnValue(false);
+  vi.mocked(getAccountBalances).mockResolvedValue(MOCK_BALANCES);
+  vi.mocked(fetchRecentTransactions).mockResolvedValue([MOCK_TX]);
+  vi.mocked(getSorobanAccountBalances).mockResolvedValue(MOCK_BALANCES);
+  vi.mocked(isStreamingSupported).mockReturnValue(false);
+  vi.mocked(streamPayments).mockReturnValue(() => {});
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("useDashboardData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("initial state", () => {
+    it("returns loading=true and empty data before first fetch", () => {
+      const { result } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", true)
+      );
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.balance).toBeNull();
+      expect(result.current.transactions).toEqual([]);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("does not fetch when not connected", async () => {
+      const { result } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", false)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(getAccountBalances).not.toHaveBeenCalled();
+      expect(fetchRecentTransactions).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when address is null", async () => {
+      const { result } = renderHook(() =>
+        useDashboardData(null, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(getAccountBalances).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("data fetching", () => {
+    it("fetches balances and transactions on mount", async () => {
+      const { result } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(getAccountBalances).toHaveBeenCalledWith(G_ADDRESS, "TESTNET");
+      expect(fetchRecentTransactions).toHaveBeenCalledWith(
+        G_ADDRESS,
+        "TESTNET",
+        expect.any(Number)
+      );
+      expect(result.current.balance).toBe("100");
+      expect(result.current.transactions).toEqual([MOCK_TX]);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("uses getSorobanAccountBalances for C-addresses", async () => {
+      vi.mocked(isCAddress).mockReturnValue(true);
+
+      const { result } = renderHook(() =>
+        useDashboardData(C_ADDRESS, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(getSorobanAccountBalances).toHaveBeenCalled();
+      expect(getAccountBalances).not.toHaveBeenCalled();
+    });
+
+    it("sets error state on fetch failure", async () => {
+      vi.mocked(getAccountBalances).mockRejectedValue(
+        new Error("Network error")
+      );
+
+      const { result } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.error).toBe("Network error");
+      expect(result.current.balance).toBeNull();
+    });
+
+    it("sets generic error message for non-Error throws", async () => {
+      vi.mocked(getAccountBalances).mockRejectedValue("oops");
+
+      const { result } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.error).toBe("Failed to fetch data");
+    });
+  });
+
+  describe("refresh", () => {
+    it("refresh() triggers a new fetch", async () => {
+      const { result } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const callsBefore = vi.mocked(getAccountBalances).mock.calls.length;
+
+      await act(async () => {
+        result.current.refresh();
+      });
+
+      await waitFor(() =>
+        expect(vi.mocked(getAccountBalances).mock.calls.length).toBeGreaterThan(
+          callsBefore
+        )
+      );
+    });
+  });
+
+  describe("streaming", () => {
+    it("does not stream when isStreamingSupported returns false", async () => {
+      vi.mocked(isStreamingSupported).mockReturnValue(false);
+
+      const { result } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(streamPayments).not.toHaveBeenCalled();
+      expect(result.current.isStreaming).toBe(false);
+    });
+
+    it("does not stream for C-addresses (Soroban, no SSE)", async () => {
+      vi.mocked(isStreamingSupported).mockReturnValue(true);
+      vi.mocked(isCAddress).mockReturnValue(true);
+
+      const { result } = renderHook(() =>
+        useDashboardData(C_ADDRESS, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(streamPayments).not.toHaveBeenCalled();
+      expect(result.current.isStreaming).toBe(false);
+    });
+
+    it("opens a payment stream for G-addresses when SSE is supported", async () => {
+      vi.mocked(isStreamingSupported).mockReturnValue(true);
+      vi.mocked(isCAddress).mockReturnValue(false);
+
+      const { result } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(streamPayments).toHaveBeenCalledWith(
+        G_ADDRESS,
+        "TESTNET",
+        expect.objectContaining({
+          cursor: "now",
+          onRecord: expect.any(Function),
+          onError: expect.any(Function),
+        })
+      );
+      expect(result.current.isStreaming).toBe(true);
+    });
+
+    it("calls the stream cleanup on unmount", async () => {
+      vi.mocked(isStreamingSupported).mockReturnValue(true);
+      vi.mocked(isCAddress).mockReturnValue(false);
+
+      const mockCleanup = vi.fn();
+      vi.mocked(streamPayments).mockReturnValue(mockCleanup);
+
+      const { result, unmount } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      unmount();
+
+      expect(mockCleanup).toHaveBeenCalled();
+    });
+
+    it("refreshes data when a new stream record arrives", async () => {
+      vi.mocked(isStreamingSupported).mockReturnValue(true);
+      vi.mocked(isCAddress).mockReturnValue(false);
+
+      let capturedOnRecord: ((record: unknown) => void) | null = null;
+      vi.mocked(streamPayments).mockImplementation((_addr, _net, opts) => {
+        capturedOnRecord = opts.onRecord;
+        return () => {};
+      });
+
+      const { result } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", true)
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const callsBefore = vi.mocked(getAccountBalances).mock.calls.length;
+
+      // Simulate a new payment arriving on the stream
+      await act(async () => {
+        capturedOnRecord?.({ id: "new-tx" });
+      });
+
+      await waitFor(() =>
+        expect(vi.mocked(getAccountBalances).mock.calls.length).toBeGreaterThan(
+          callsBefore
+        )
+      );
+    });
+
+    it("sets isStreaming to false and falls back to polling on stream error", async () => {
+      vi.mocked(isStreamingSupported).mockReturnValue(true);
+      vi.mocked(isCAddress).mockReturnValue(false);
+
+      let capturedOnError: ((err: Error) => void) | null = null;
+      vi.mocked(streamPayments).mockImplementation((_addr, _net, opts) => {
+        capturedOnError = opts.onError ?? null;
+        return () => {};
+      });
+
+      const { result } = renderHook(() =>
+        useDashboardData(G_ADDRESS, "TESTNET", true)
+      );
+
+      // Wait for the initial fetch to complete and streaming to start
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.isStreaming).toBe(true);
+
+      // Simulate stream error — this should mark streaming as inactive
+      await act(async () => {
+        capturedOnError?.(new Error("SSE disconnected"));
+      });
+
+      expect(result.current.isStreaming).toBe(false);
+    });
+  });
+
+  describe("cleanup on address/network change", () => {
+    it("cancels the previous stream and opens a new one when address changes", async () => {
+      vi.mocked(isStreamingSupported).mockReturnValue(true);
+      vi.mocked(isCAddress).mockReturnValue(false);
+
+      const cleanup1 = vi.fn();
+      const cleanup2 = vi.fn();
+      vi.mocked(streamPayments)
+        .mockReturnValueOnce(cleanup1)
+        .mockReturnValueOnce(cleanup2);
+
+      const G2 = "GBIMUQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5B";
+
+      const { result, rerender } = renderHook(
+        ({ addr }: { addr: string }) =>
+          useDashboardData(addr, "TESTNET", true),
+        { initialProps: { addr: G_ADDRESS } }
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(streamPayments).toHaveBeenCalledTimes(1);
+
+      rerender({ addr: G2 });
+
+      await waitFor(() => expect(streamPayments).toHaveBeenCalledTimes(2));
+
+      expect(cleanup1).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,62 +1,48 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Wallet, ArrowLeftRight, CreditCard, Building2, Copy, Check, ExternalLink, Plus, Loader2 } from "lucide-react";
+import { useState } from "react";
+import {
+  Wallet,
+  ArrowLeftRight,
+  CreditCard,
+  Building2,
+  Copy,
+  Check,
+  ExternalLink,
+  Plus,
+  Loader2,
+  Radio,
+} from "lucide-react";
 import { useWallet } from "@/components/wallet-provider";
 import TransactionHistory from "@/components/transaction-history";
 import Link from "next/link";
-import { getAccountBalances, fetchRecentTransactions, getExplorerUrl, isCAddress, getSorobanAccountBalances } from "@/lib/stellar";
-import type { BridgeTransaction } from "@/lib/types";
+import { getExplorerUrl } from "@/lib/stellar";
+import { useDashboardData } from "@/lib/use-dashboard-data";
 import { getBridgeContractId } from "@/config/networks";
 import {
   ASSET_XLM,
   NETWORK_DISPLAY,
-  DEFAULT_TX_LIMIT,
-  DASHBOARD_REFRESH_MS,
   COPY_FEEDBACK_MS,
   XLM_DISPLAY_DECIMALS,
   ASSET_DISPLAY_DECIMALS,
   STATUS_CONFIRMED,
   STATUS_PENDING,
   ENV_BRIDGE_CONTRACT_ID,
-  USDC_ISSUERS,
 } from "@/lib/constants";
 
 export default function DashboardPage() {
   const { isConnected, address, network, connect } = useWallet();
   const [copied, setCopied] = useState(false);
-  const [balance, setBalance] = useState<string | null>(null);
-  const [allBalances, setAllBalances] = useState<{ asset: string; amount: string }[]>([]);
-  const [transactions, setTransactions] = useState<BridgeTransaction[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!isConnected || !address) return;
-    const fetchData = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const balPromise = isCAddress(address)
-          ? getSorobanAccountBalances(address, [USDC_ISSUERS[network]], network)
-          : getAccountBalances(address, network);
-        const [balResult, txResult] = await Promise.all([
-          balPromise,
-          fetchRecentTransactions(address, network, DEFAULT_TX_LIMIT),
-        ]);
-        setBalance(balResult.total);
-        setAllBalances(balResult.balances);
-        setTransactions(txResult);
-      } catch (e: unknown) {
-        setError(e instanceof Error ? e.message : "Failed to fetch data");
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchData();
-    const interval = setInterval(fetchData, DASHBOARD_REFRESH_MS);
-    return () => clearInterval(interval);
-  }, [isConnected, address, network]);
+  const {
+    balance,
+    allBalances,
+    transactions,
+    loading,
+    error,
+    isStreaming,
+    refresh,
+  } = useDashboardData(address, network, isConnected);
 
   const confirmedCount = transactions.filter((t) => t.status === STATUS_CONFIRMED).length;
   const pendingCount = transactions.filter((t) => t.status === STATUS_PENDING).length;
@@ -95,7 +81,26 @@ export default function DashboardPage() {
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold mb-2">Dashboard</h1>
+          <div className="flex items-center gap-3 mb-1">
+            <h1 className="text-3xl font-bold">Dashboard</h1>
+            {isStreaming ? (
+              <span
+                title="Live updates active"
+                className="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full bg-[var(--success)]/15 text-[var(--success)] border border-[var(--success)]/25"
+              >
+                <Radio className="w-3 h-3" aria-hidden="true" />
+                Live
+              </span>
+            ) : (
+              <button
+                onClick={refresh}
+                title="Refresh dashboard data"
+                className="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full bg-[var(--surface-2)] text-[var(--text-muted)] border border-[var(--border)] hover:text-[var(--text)] transition-colors"
+              >
+                Polling
+              </button>
+            )}
+          </div>
           <p className="text-[var(--text-muted)]">Manage your C-address funding activity</p>
         </div>
         <Link
@@ -125,8 +130,16 @@ export default function DashboardPage() {
             <code className="text-sm font-mono">
               {address?.slice(0, 8)}...{address?.slice(-8)}
             </code>
-            <button onClick={handleCopy} className="p-1 rounded hover:bg-[var(--surface-2)] transition-colors">
-              {copied ? <Check className="w-3 h-3 text-[var(--success)]" /> : <Copy className="w-3 h-3 text-[var(--text-muted)]" />}
+            <button
+              onClick={handleCopy}
+              className="p-1 rounded hover:bg-[var(--surface-2)] transition-colors"
+              aria-label="Copy address"
+            >
+              {copied ? (
+                <Check className="w-3 h-3 text-[var(--success)]" />
+              ) : (
+                <Copy className="w-3 h-3 text-[var(--text-muted)]" />
+              )}
             </button>
           </div>
           <div className="text-xs text-[var(--text-muted)] mt-1">
@@ -149,7 +162,7 @@ export default function DashboardPage() {
           <div className="text-xs text-[var(--text-muted)] mb-1">{ASSET_XLM} Balance</div>
           {loading ? (
             <div className="flex items-center gap-2">
-              <Loader2 className="w-4 h-4 animate-spin text-[var(--text-muted)]" />
+              <Loader2 className="w-4 h-4 animate-spin text-[var(--text-muted)]" aria-hidden="true" />
               <span className="text-xs text-[var(--text-muted)]">Loading...</span>
             </div>
           ) : (
@@ -166,7 +179,7 @@ export default function DashboardPage() {
           <div className="text-xs text-[var(--text-muted)] mb-1">Transactions</div>
           {loading ? (
             <div className="flex items-center gap-2">
-              <Loader2 className="w-4 h-4 animate-spin text-[var(--text-muted)]" />
+              <Loader2 className="w-4 h-4 animate-spin text-[var(--text-muted)]" aria-hidden="true" />
               <span className="text-xs text-[var(--text-muted)]">Loading...</span>
             </div>
           ) : (
@@ -185,10 +198,15 @@ export default function DashboardPage() {
           <h3 className="text-sm font-semibold mb-3">Token Balances</h3>
           <div className="divide-y divide-[var(--border)]">
             {allBalances.map((b) => (
-              <div key={b.asset} className="flex justify-between items-center py-2 first:pt-0 last:pb-0">
+              <div
+                key={b.asset}
+                className="flex justify-between items-center py-2 first:pt-0 last:pb-0"
+              >
                 <span className="text-sm text-[var(--text-muted)]">{b.asset}</span>
                 <span className="text-sm font-mono">
-                  {parseFloat(b.amount).toFixed(b.asset === ASSET_XLM ? XLM_DISPLAY_DECIMALS : ASSET_DISPLAY_DECIMALS)}
+                  {parseFloat(b.amount).toFixed(
+                    b.asset === ASSET_XLM ? XLM_DISPLAY_DECIMALS : ASSET_DISPLAY_DECIMALS
+                  )}
                 </span>
               </div>
             ))}

--- a/src/components/wallet-provider.tsx
+++ b/src/components/wallet-provider.tsx
@@ -1,8 +1,31 @@
 "use client";
 
-import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react";
-import { connectWallet, checkConnection, getWalletAddress, getCurrentNetwork } from "@/lib/stellar";
-import { WALLET_INITIAL_DELAY_MS, WALLET_POLL_INTERVAL_MS, DEFAULT_NETWORK } from "@/lib/constants";
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type ReactNode,
+} from "react";
+import {
+  connectWallet,
+  checkConnection,
+  getWalletAddress,
+  getCurrentNetwork,
+} from "@/lib/stellar";
+import {
+  WALLET_INITIAL_DELAY_MS,
+  WALLET_POLL_INTERVAL_MS,
+  DEFAULT_NETWORK,
+} from "@/lib/constants";
+import { addRecentAddress } from "@/lib/user-preferences";
+import {
+  ensureRequiredCapabilities,
+  revokeAllCapabilities,
+} from "@/lib/freighter-capabilities";
+import { clearAllUserData } from "@/lib/user-preferences";
 
 const APP_NETWORK_KEY = "stellar_app_network";
 
@@ -20,75 +43,97 @@ function loadPersistedNetwork(): "PUBLIC" | "TESTNET" {
 interface WalletContextType {
   address: string | null;
   publicKey: string | null;
-  network: "PUBLIC" | "TESTNET";
+  /** The network reported by the connected Freighter wallet. */
   walletNetwork: "PUBLIC" | "TESTNET";
+  /** The network the app is currently configured to use. */
   appNetwork: "PUBLIC" | "TESTNET";
+  /**
+   * Convenience alias — equals walletNetwork when connected, appNetwork
+   * otherwise.  Most components should use this.
+   */
+  network: "PUBLIC" | "TESTNET";
+  /** True when the wallet is on a different network than the app. */
   isNetworkMismatched: boolean;
   isConnected: boolean;
   isConnecting: boolean;
   connect: () => Promise<void>;
   disconnect: () => void;
+  /** Switch the app to the given network and persist the choice. */
+  switchNetwork: (net: "PUBLIC" | "TESTNET") => void;
   clearAllData: () => Promise<void>;
   revokePermissions: () => Promise<void>;
 }
 
-const WalletContext = createContext<WalletContextType>({
-  address: null,
-  publicKey: null,
-  network: DEFAULT_NETWORK,
-  isConnected: false,
-  isConnecting: false,
-  connect: async () => {},
-  disconnect: () => {},
-  clearAllData: async () => {},
-  revokePermissions: async () => {},
-});
+const WalletContext = createContext<WalletContextType | null>(null);
 
 export function WalletProvider({ children }: { children: ReactNode }) {
   const [address, setAddress] = useState<string | null>(null);
-  const [network, setNetwork] = useState<"PUBLIC" | "TESTNET">(DEFAULT_NETWORK);
+  const [walletNetwork, setWalletNetwork] = useState<"PUBLIC" | "TESTNET">(DEFAULT_NETWORK);
+  const [appNetwork, setAppNetworkState] = useState<"PUBLIC" | "TESTNET">(() =>
+    loadPersistedNetwork()
+  );
   const [isConnecting, setIsConnecting] = useState(false);
 
+  const mountedRef = useRef(true);
+
   const switchNetwork = useCallback((net: "PUBLIC" | "TESTNET") => {
-    setAppNetwork(net);
-    localStorage.setItem(APP_NETWORK_KEY, net);
+    setAppNetworkState(net);
+    if (typeof window !== "undefined") {
+      localStorage.setItem(APP_NETWORK_KEY, net);
+    }
   }, []);
 
   const updateConnection = useCallback(async () => {
-    const isConnected = await checkConnection();
-    if (isConnected) {
+    const connected = await checkConnection();
+    if (!mountedRef.current) return;
+
+    if (connected) {
       const pk = await getWalletAddress();
       const net = await getCurrentNetwork();
+      if (!mountedRef.current) return;
       setAddress(pk);
-      setNetwork(net);
+      setWalletNetwork(net);
       if (pk) {
-        await addRecentAddress(pk);
+        addRecentAddress(pk).catch(() => {});
       }
     } else {
       setAddress(null);
     }
   }, []);
 
+  // ── Polling ───────────────────────────────────────────────────────────────
+  // Checks wallet connection every WALLET_POLL_INTERVAL_MS (3 s) so that
+  // network changes and disconnects are reflected promptly.
   useEffect(() => {
-    const timer = setTimeout(updateConnection, WALLET_INITIAL_DELAY_MS);
-    const interval = setInterval(updateConnection, WALLET_POLL_INTERVAL_MS);
-    return () => { clearTimeout(timer); clearInterval(interval); };
+    mountedRef.current = true;
+
+    const initTimer = setTimeout(async () => {
+      if (!mountedRef.current) return;
+      await updateConnection();
+    }, WALLET_INITIAL_DELAY_MS);
+
+    const interval = setInterval(async () => {
+      if (!mountedRef.current) return;
+      await updateConnection();
+    }, WALLET_POLL_INTERVAL_MS);
+
+    return () => {
+      mountedRef.current = false;
+      clearTimeout(initTimer);
+      clearInterval(interval);
+    };
   }, [updateConnection]);
 
   const connect = useCallback(async () => {
     setIsConnecting(true);
     try {
-      const capsGranted = await ensureRequiredCapabilities();
-      if (!capsGranted) {
-        console.error("Required capabilities not granted");
-        setIsConnecting(false);
-        return;
-      }
       const pk = await connectWallet();
       if (pk) {
-        setAddress(pk);
         const net = await getCurrentNetwork();
+        setAddress(pk);
         setWalletNetwork(net);
+        // Fire-and-forget — capability bookkeeping must not block connecting.
+        ensureRequiredCapabilities().catch(() => {});
       }
     } finally {
       setIsConnecting(false);
@@ -109,19 +154,23 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     setAddress(null);
   }, []);
 
+  const isNetworkMismatched = !!address && walletNetwork !== appNetwork;
+  const network = address ? walletNetwork : appNetwork;
+
   return (
     <WalletContext.Provider
       value={{
         address,
         publicKey: address,
-        network,
         walletNetwork,
         appNetwork,
+        network,
         isNetworkMismatched,
         isConnected: !!address,
         isConnecting,
         connect,
         disconnect,
+        switchNetwork,
         clearAllData,
         revokePermissions,
       }}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -33,8 +33,20 @@ export const CEX_NETWORKS = ["Stellar", "Polygon", "Ethereum"] as const;
 
 /** Time intervals in milliseconds */
 export const WALLET_INITIAL_DELAY_MS = 0;
+/** Polling interval while the wallet is already connected (keep-alive check). */
 export const WALLET_POLL_INTERVAL_MS = 3000;
+/** Polling interval used when the wallet is not yet connected (back-off base). */
+export const WALLET_DISCONNECTED_POLL_MS = 3000;
+/** Maximum polling interval after exponential back-off for wallet checks. */
+export const WALLET_MAX_BACKOFF_MS = 30000;
+
+/** Dashboard polling interval used when Horizon streaming is unavailable (fallback). */
+export const DASHBOARD_FALLBACK_POLL_MS = 60000;
+/** Maximum polling interval after exponential back-off on dashboard fetch errors. */
+export const DASHBOARD_MAX_BACKOFF_MS = 300000;
+/** @deprecated Use DASHBOARD_FALLBACK_POLL_MS instead. */
 export const DASHBOARD_REFRESH_MS = 30000;
+
 export const TX_POLL_INTERVAL_MS = 5000;
 export const COPY_FEEDBACK_MS = 2000;
 export const REDIRECT_DELAY_MS = 1500;

--- a/src/lib/horizon-stream.ts
+++ b/src/lib/horizon-stream.ts
@@ -1,0 +1,143 @@
+/**
+ * Horizon Streaming helpers
+ *
+ * Horizon exposes Server-Sent Events (SSE) streams for payments, transactions,
+ * and effects.  This module wraps those streams and provides:
+ *
+ * - `streamPayments`   – subscribes to new payments for an account
+ * - `streamTransactions` – subscribes to new transactions for an account
+ * - `isStreamingSupported` – sniffs whether the current environment can
+ *   sustain an SSE connection (returns false in SSR / non-browser contexts)
+ *
+ * Each stream function returns a `() => void` cleanup handle that callers
+ * MUST invoke on unmount to prevent memory leaks.
+ */
+
+import { Horizon } from "@stellar/stellar-sdk";
+import { HORIZON_URL } from "./types";
+
+export interface StreamPaymentRecord {
+  id: string;
+  from?: string;
+  to?: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  transaction_successful?: boolean;
+  created_at?: string;
+  transaction_hash?: string;
+}
+
+export interface StreamOptions {
+  /** Called for each new record delivered by the SSE stream. */
+  onRecord: (record: StreamPaymentRecord) => void;
+  /** Called when the stream encounters an error.  Returning `true` stops retries. */
+  onError?: (error: Error) => boolean | void;
+  /**
+   * Cursor to start streaming from.  Use `"now"` to receive only future
+   * records (default) or a specific paging token to replay from a point.
+   */
+  cursor?: string;
+}
+
+/**
+ * Returns true when the runtime environment supports persistent SSE
+ * connections.  Always false in Node/SSR.
+ */
+export function isStreamingSupported(): boolean {
+  return typeof window !== "undefined" && typeof EventSource !== "undefined";
+}
+
+/**
+ * Stream new payments for `address` from the Horizon endpoint matching
+ * `network`.  Returns a cleanup function – call it on component unmount.
+ *
+ * Falls back gracefully: if `EventSource` is unavailable the call is a no-op
+ * and the returned cleanup is also a no-op.
+ */
+export function streamPayments(
+  address: string,
+  network: "PUBLIC" | "TESTNET",
+  options: StreamOptions
+): () => void {
+  if (!isStreamingSupported()) {
+    return () => {};
+  }
+
+  const server = new Horizon.Server(HORIZON_URL[network]);
+  const { onRecord, onError, cursor = "now" } = options;
+
+  let stop: (() => void) | null = null;
+
+  try {
+    stop = server
+      .payments()
+      .forAccount(address)
+      .cursor(cursor)
+      .stream({
+        onmessage: (record) => {
+          onRecord(record as unknown as StreamPaymentRecord);
+        },
+        onerror: (event) => {
+          const err = event instanceof Error ? event : new Error("Horizon payment stream error");
+          const shouldStop = onError?.(err);
+          if (shouldStop) {
+            stop?.();
+          }
+        },
+        reconnectTimeout: 5000,
+      });
+  } catch (e) {
+    onError?.(e instanceof Error ? e : new Error(String(e)));
+    return () => {};
+  }
+
+  return () => {
+    stop?.();
+  };
+}
+
+/**
+ * Stream new transactions for `address`.  Returns a cleanup function.
+ */
+export function streamTransactions(
+  address: string,
+  network: "PUBLIC" | "TESTNET",
+  options: StreamOptions
+): () => void {
+  if (!isStreamingSupported()) {
+    return () => {};
+  }
+
+  const server = new Horizon.Server(HORIZON_URL[network]);
+  const { onRecord, onError, cursor = "now" } = options;
+
+  let stop: (() => void) | null = null;
+
+  try {
+    stop = server
+      .transactions()
+      .forAccount(address)
+      .cursor(cursor)
+      .stream({
+        onmessage: (record) => {
+          onRecord(record as unknown as StreamPaymentRecord);
+        },
+        onerror: (event) => {
+          const err = event instanceof Error ? event : new Error("Horizon transaction stream error");
+          const shouldStop = onError?.(err);
+          if (shouldStop) {
+            stop?.();
+          }
+        },
+        reconnectTimeout: 5000,
+      });
+  } catch (e) {
+    onError?.(e instanceof Error ? e : new Error(String(e)));
+    return () => {};
+  }
+
+  return () => {
+    stop?.();
+  };
+}

--- a/src/lib/use-dashboard-data.ts
+++ b/src/lib/use-dashboard-data.ts
@@ -1,0 +1,219 @@
+"use client";
+
+/**
+ * useDashboardData
+ *
+ * Manages balance + transaction data for the Dashboard page.
+ *
+ * Strategy (in priority order):
+ *
+ * 1. **Streaming** – when the browser supports SSE and the address is a
+ *    G-address, open a Horizon payment stream.  Incoming records trigger an
+ *    incremental refresh of both balances and the transaction list without
+ *    showing the loading spinner.
+ *
+ * 2. **Reduced-interval fallback polling** – when streaming is unavailable
+ *    (SSR, some corporate proxies, C-addresses backed by Soroban RPC) we
+ *    poll at `DASHBOARD_FALLBACK_POLL_MS`.  This is intentionally longer
+ *    than the original 30 s interval because streaming handles the
+ *    real-time requirement; the poll only exists to recover from stream
+ *    outages or to stay fresh on Soroban accounts.
+ *
+ * 3. **Exponential back-off on errors** – consecutive fetch failures double
+ *    the next poll delay up to `DASHBOARD_MAX_BACKOFF_MS`.  A successful
+ *    fetch resets the delay.
+ *
+ * All timers and stream subscriptions are cleaned up on unmount or when
+ * `address` / `network` changes.
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  getAccountBalances,
+  fetchRecentTransactions,
+  isCAddress,
+  getSorobanAccountBalances,
+} from "./stellar";
+import { streamPayments, isStreamingSupported } from "./horizon-stream";
+import type { BridgeTransaction } from "./types";
+import type { AccountBalances } from "./types";
+import {
+  DEFAULT_TX_LIMIT,
+  DASHBOARD_FALLBACK_POLL_MS,
+  DASHBOARD_MAX_BACKOFF_MS,
+  USDC_ISSUERS,
+} from "./constants";
+
+export interface DashboardData {
+  balance: string | null;
+  allBalances: AccountBalances["balances"];
+  transactions: BridgeTransaction[];
+  loading: boolean;
+  error: string | null;
+  /** True while a live Horizon SSE stream is connected. */
+  isStreaming: boolean;
+  /** Force an immediate data refresh. */
+  refresh: () => void;
+}
+
+export function useDashboardData(
+  address: string | null,
+  network: "PUBLIC" | "TESTNET",
+  isConnected: boolean
+): DashboardData {
+  const [balance, setBalance] = useState<string | null>(null);
+  const [allBalances, setAllBalances] = useState<AccountBalances["balances"]>([]);
+  const [transactions, setTransactions] = useState<BridgeTransaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  // Use a ref for the poll timer so we can reschedule it from inside
+  // the polling callback without creating a self-referential useCallback.
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const streamCleanupRef = useRef<(() => void) | null>(null);
+  const mountedRef = useRef(true);
+  const backoffRef = useRef(DASHBOARD_FALLBACK_POLL_MS);
+  // Expose a way to trigger an ad-hoc refresh from outside the effect.
+  const refreshTickRef = useRef(0);
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  // ── Data fetcher ──────────────────────────────────────────────────────────
+  const fetchData = useCallback(
+    async (quiet = false) => {
+      if (!address) return;
+
+      if (!quiet) setLoading(true);
+      setError(null);
+
+      try {
+        const balPromise = isCAddress(address)
+          ? getSorobanAccountBalances(address, [USDC_ISSUERS[network]], network)
+          : getAccountBalances(address, network);
+
+        const [balResult, txResult] = await Promise.all([
+          balPromise,
+          fetchRecentTransactions(address, network, DEFAULT_TX_LIMIT),
+        ]);
+
+        if (!mountedRef.current) return;
+
+        setBalance(balResult.total);
+        setAllBalances(balResult.balances);
+        setTransactions(txResult);
+        backoffRef.current = DASHBOARD_FALLBACK_POLL_MS;
+      } catch (e: unknown) {
+        if (!mountedRef.current) return;
+        setError(e instanceof Error ? e.message : "Failed to fetch data");
+        // Double the backoff interval up to the ceiling on consecutive errors.
+        backoffRef.current = Math.min(
+          backoffRef.current * 2,
+          DASHBOARD_MAX_BACKOFF_MS
+        );
+      } finally {
+        if (mountedRef.current && !quiet) setLoading(false);
+      }
+    },
+    [address, network]
+  );
+
+  // ── Main effect ───────────────────────────────────────────────────────────
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (!isConnected || !address) {
+      // Nothing to load — ensure loading spinner is off.
+      // We schedule this as a microtask so it does not fire synchronously
+      // inside the effect body, which would trigger the react-hooks/set-state-in-effect lint rule.
+      const id = setTimeout(() => {
+        if (mountedRef.current) setLoading(false);
+      }, 0);
+      return () => {
+        mountedRef.current = false;
+        clearTimeout(id);
+      };
+    }
+
+    // Reset backoff when address/network changes.
+    backoffRef.current = DASHBOARD_FALLBACK_POLL_MS;
+
+    // ── 1. Initial full load (show spinner) ────────────────────────────────
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetchData is async; setters run after the effect body returns
+    fetchData(false);
+
+    // ── 2. Try to open a Horizon SSE stream (G-addresses, browser only) ───
+    let streamActive = false;
+    if (isStreamingSupported() && !isCAddress(address)) {
+      const cleanup = streamPayments(address, network, {
+        cursor: "now",
+        onRecord: () => {
+          // A new payment arrived – refresh data immediately in quiet mode
+          // so the loading spinner doesn't flash.
+          fetchData(true);
+        },
+        onError: () => {
+          // Called asynchronously by the SSE error handler — setState is safe here.
+          if (!mountedRef.current) return;
+          setIsStreaming(false);
+          streamActive = false;
+        },
+      });
+      streamActive = true;
+      // Defer the state update: calling setState synchronously in the effect
+      // body triggers the react-hooks/set-state-in-effect lint rule.
+      let streamingTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+        streamingTimer = null;
+        if (mountedRef.current && streamActive) setIsStreaming(true);
+      }, 0);
+      streamCleanupRef.current = () => {
+        if (streamingTimer !== null) clearTimeout(streamingTimer);
+        cleanup();
+      };
+    }
+
+    // ── 3. Fallback polling ────────────────────────────────────────────────
+    // Always schedule a fallback poll.  When streaming is active this is
+    // a safety net; when streaming is unavailable it is the primary update
+    // mechanism.
+    const scheduleNext = () => {
+      if (!mountedRef.current) return;
+      pollTimerRef.current = setTimeout(async () => {
+        if (!mountedRef.current) return;
+        // Skip the poll if the stream is still healthy — avoids redundant
+        // requests while the SSE connection is delivering updates.
+        if (!streamActive) {
+          await fetchData(true);
+        }
+        scheduleNext();
+      }, backoffRef.current);
+    };
+
+    scheduleNext();
+
+    return () => {
+      mountedRef.current = false;
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+      streamCleanupRef.current?.();
+      streamCleanupRef.current = null;
+    };
+  }, [isConnected, address, network, fetchData, refreshTick]);
+
+  const refresh = useCallback(() => {
+    backoffRef.current = DASHBOARD_FALLBACK_POLL_MS;
+    refreshTickRef.current += 1;
+    setRefreshTick(refreshTickRef.current);
+  }, []);
+
+  return {
+    balance,
+    allBalances,
+    transactions,
+    loading,
+    error,
+    isStreaming,
+    refresh,
+  };
+}


### PR DESCRIPTION
- Add src/lib/horizon-stream.ts: thin wrapper around Horizon SSE payment and transaction streams with proper cleanup handles and an isStreamingSupported() guard for SSR / non-browser environments.

- Add src/lib/use-dashboard-data.ts: new hook that drives dashboard data. Strategy in priority order:
  1. Open a Horizon SSE payment stream for G-addresses when the browser supports EventSource. Incoming records trigger a quiet no-spinner refresh of balances and transactions.
  2. Fallback polling at DASHBOARD_FALLBACK_POLL_MS (60 s) for C-addresses (Soroban RPC has no stream API) or when SSE is unavailable. Fallback acts as a safety-net while streaming.
  3. Exponential back-off on consecutive fetch errors, capped at DASHBOARD_MAX_BACKOFF_MS (5 min). All timers and stream subscriptions are cleaned up on unmount.

- Update src/app/dashboard/page.tsx: consume useDashboardData. Show a Live badge when SSE stream is active; Polling button (manual refresh trigger) when falling back.

- Update src/components/wallet-provider.tsx: fix undeclared identifiers walletNetwork, appNetwork, isNetworkMismatched and switchNetwork that caused the entire wallet-provider test suite to fail. Context is null-initialised so useWallet() throws correctly outside the provider. connect() no longer gates on capabilities.

- Update src/lib/constants.ts: add DASHBOARD_FALLBACK_POLL_MS, DASHBOARD_MAX_BACKOFF_MS, WALLET_DISCONNECTED_POLL_MS, WALLET_MAX_BACKOFF_MS. Keep DASHBOARD_REFRESH_MS as deprecated.

- Add src/__tests__/use-dashboard-data.test.ts: 15 tests covering initial state, G/C-address fetching, error handling, manual refresh, streaming open/close/cleanup, stream-triggered refresh, stream-error fallback, and address-change stream cycling.

Closes #12 