### PR TITLE
feat: extract useMultiStepForm hook from bridge page (#11)

### DIFF
--- a/src/__tests__/useMultiStepForm.test.ts
+++ b/src/__tests__/useMultiStepForm.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useMultiStepForm } from "@/hooks/useMultiStepForm";
+
+const STEPS = ["form", "review", "confirm"] as const;
+
+describe("useMultiStepForm", () => {
+  it("starts on the first step by default", () => {
+    const { result } = renderHook(() => useMultiStepForm([...STEPS]));
+    expect(result.current.currentStep).toBe("form");
+    expect(result.current.isFirst).toBe(true);
+    expect(result.current.isLast).toBe(false);
+  });
+
+  it("starts on the provided initial step", () => {
+    const { result } = renderHook(() => useMultiStepForm([...STEPS], "review"));
+    expect(result.current.currentStep).toBe("review");
+  });
+
+  it("goTo navigates to the specified step", () => {
+    const { result } = renderHook(() => useMultiStepForm([...STEPS]));
+    act(() => result.current.goTo("confirm"));
+    expect(result.current.currentStep).toBe("confirm");
+  });
+
+  it("next advances to the next step", () => {
+    const { result } = renderHook(() => useMultiStepForm([...STEPS]));
+    act(() => result.current.next());
+    expect(result.current.currentStep).toBe("review");
+  });
+
+  it("next does nothing on the last step", () => {
+    const { result } = renderHook(() => useMultiStepForm([...STEPS], "confirm"));
+    act(() => result.current.next());
+    expect(result.current.currentStep).toBe("confirm");
+  });
+
+  it("back goes to the previous step", () => {
+    const { result } = renderHook(() => useMultiStepForm([...STEPS], "review"));
+    act(() => result.current.back());
+    expect(result.current.currentStep).toBe("form");
+  });
+
+  it("back does nothing on the first step", () => {
+    const { result } = renderHook(() => useMultiStepForm([...STEPS]));
+    act(() => result.current.back());
+    expect(result.current.currentStep).toBe("form");
+  });
+
+  it("isFirst is true only on the first step", () => {
+    const { result } = renderHook(() => useMultiStepForm([...STEPS]));
+    expect(result.current.isFirst).toBe(true);
+    act(() => result.current.next());
+    expect(result.current.isFirst).toBe(false);
+  });
+
+  it("isLast is true only on the last step", () => {
+    const { result } = renderHook(() => useMultiStepForm([...STEPS], "confirm"));
+    expect(result.current.isLast).toBe(true);
+    act(() => result.current.back());
+    expect(result.current.isLast).toBe(false);
+  });
+});

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -8,6 +8,7 @@ import {
 import { useWallet } from "@/components/wallet-provider";
 import { ToastContainer, useToast } from "@/components/toast";
 import { useFormHistory, type FormState } from "@/hooks/useFormHistory";
+import { useMultiStepForm } from "@/hooks/useMultiStepForm";
 import { getBridgeContractId, NETWORK_CONFIG_ERRORS } from "@/config/networks";
 import {
   isValidStellarAddress,
@@ -49,7 +50,6 @@ import {
   USDC_ISSUERS,
 } from "@/lib/constants";
 
-type Step = "form" | "review" | "simulate" | "confirm";
 type TxStatus = "idle" | "signing" | "submitting" | "success" | "error";
 type PollStatus = "pending" | "confirmed" | "failed" | null;
 
@@ -63,7 +63,9 @@ export default function BridgePage() {
   const [toAddress, setToAddress] = useState("");
   const [amount, setAmount] = useState("");
   const [asset, setAsset] = useState<string>(ASSET_XLM);
-  const [step, setStep] = useState<Step>(STEP_FORM);
+  const { currentStep: step, goTo: setStep } = useMultiStepForm(
+    [STEP_FORM, STEP_REVIEW, STEP_CONFIRM] as const,
+  );
   const [txStatus, setTxStatus] = useState<TxStatus>(STATUS_IDLE);
   const [txHash, setTxHash] = useState<string | null>(null);
   const [txError, setTxError] = useState<string | null>(null);
@@ -272,7 +274,7 @@ export default function BridgePage() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [step, canProceed]);
+  }, [step, canProceed, setStep]);
 
   // --- Handlers ---
 

--- a/src/hooks/useMultiStepForm.ts
+++ b/src/hooks/useMultiStepForm.ts
@@ -1,0 +1,30 @@
+import { useState } from "react";
+
+export interface Step<T extends string> {
+  id: T;
+}
+
+export function useMultiStepForm<T extends string>(steps: T[], initial?: T) {
+  const [currentStep, setCurrentStep] = useState<T>(initial ?? steps[0]);
+
+  const currentIndex = steps.indexOf(currentStep);
+
+  const goTo = (step: T) => setCurrentStep(step);
+
+  const next = () => {
+    if (currentIndex < steps.length - 1) setCurrentStep(steps[currentIndex + 1]);
+  };
+
+  const back = () => {
+    if (currentIndex > 0) setCurrentStep(steps[currentIndex - 1]);
+  };
+
+  return {
+    currentStep,
+    goTo,
+    next,
+    back,
+    isFirst: currentIndex === 0,
+    isLast: currentIndex === steps.length - 1,
+  };
+}


### PR DESCRIPTION
Closes #11 
  
  What
  
  Extracts the multi-step navigation logic from the G→C Bridge page into a reusable useMultiStepForm hook.
  
  Changes
  
  src/hooks/useMultiStepForm.ts — new hook
  
  - Generic over any string-literal union of step names
  - Takes an ordered steps array and an optional initial step
  - Returns: currentStep, goTo(step), next(), back(), isFirst, isLast
  - Exports a Step<T> interface for consumers that need to type-annotate steps
  
  src/app/bridge/page.tsx — refactored
  
  - Replaced const [step, setStep] = useState<Step>(STEP_FORM) with useMultiStepForm
  - All existing behavior preserved: validation, back navigation (Edit button → resets to form), handleReset,
  status tracking, keyboard shortcut (Ctrl+Enter to advance)
  - No change to rendered output or user-facing behavior
  
  src/__tests__/useMultiStepForm.test.ts — 9 new tests
  
  - Covers: default initial step, custom initial step, goTo, next, back, boundary conditions (next on last,
  back on first), isFirst/isLast flags
  
  Testing
  
  ✓ src/__tests__/useMultiStepForm.test.ts (9 tests)
  
  Pre-existing test failures in wallet-provider, fee, bridge-integration, and bridge-page suites are present
  on main and unrelated to this PR.