### PR TITLE
feat: add barrel exports and runtime env validation

### DIFF
--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -5,8 +5,7 @@ import {
   ArrowRightLeft, Wallet, Send, ArrowRight, Check, AlertCircle,
   Loader2, ExternalLink, XCircle, AlertTriangle, RotateCcw, RotateCw,
 } from "lucide-react";
-import { useWallet } from "@/components/wallet-provider";
-import { ToastContainer, useToast } from "@/components/toast";
+import { useWallet, ToastContainer, useToast } from "@/components";
 import { useFormHistory, type FormState } from "@/hooks/useFormHistory";
 import { getBridgeContractId, NETWORK_CONFIG_ERRORS } from "@/config/networks";
 import {
@@ -18,9 +17,6 @@ import {
   loadAccountInfo,
   buildAndSubmitChangeTrust,
   getTransactionStatus,
-} from "@/lib/stellar";
-import { validateCAddress } from "@/utils/validation";
-import {
   ASSET_XLM,
   ASSET_USDC,
   XLM_RESERVE_BUFFER,
@@ -47,7 +43,8 @@ import {
   STEP_REVIEW,
   STEP_CONFIRM,
   USDC_ISSUERS,
-} from "@/lib/constants";
+} from "@/lib";
+import { validateCAddress } from "@/utils/validation";
 
 type Step = "form" | "review" | "simulate" | "confirm";
 type TxStatus = "idle" | "signing" | "submitting" | "success" | "error";

--- a/src/app/cex/page.tsx
+++ b/src/app/cex/page.tsx
@@ -2,8 +2,14 @@
 
 import { useState } from "react";
 import { Building2, Copy, Check, ExternalLink, Wallet, Info } from "lucide-react";
-import { CEX_LIST, DEFAULT_BRIDGE_ADDRESS, DEFAULT_BRIDGE_MEMO } from "@/lib/types";
-import { CEX_NETWORKS, CEX_NETWORK_STELLAR, COPY_FEEDBACK_MS } from "@/lib/constants";
+import {
+  CEX_LIST,
+  DEFAULT_BRIDGE_ADDRESS,
+  DEFAULT_BRIDGE_MEMO,
+  CEX_NETWORKS,
+  CEX_NETWORK_STELLAR,
+  COPY_FEEDBACK_MS,
+} from "@/lib";
 import { validateCAddress } from "@/utils/validation";
 
 export default function CexPage() {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,13 +2,15 @@
 
 import { useState, useEffect } from "react";
 import { Wallet, ArrowLeftRight, CreditCard, Building2, Copy, Check, ExternalLink, Plus, Loader2 } from "lucide-react";
-import { useWallet } from "@/components/wallet-provider";
-import TransactionHistory from "@/components/transaction-history";
+import { useWallet, TransactionHistory } from "@/components";
 import Link from "next/link";
-import { getAccountBalances, fetchRecentTransactions, getExplorerUrl, isCAddress, getSorobanAccountBalances } from "@/lib/stellar";
-import type { BridgeTransaction } from "@/lib/types";
-import { getBridgeContractId } from "@/config/networks";
 import {
+  getAccountBalances,
+  fetchRecentTransactions,
+  getExplorerUrl,
+  isCAddress,
+  getSorobanAccountBalances,
+  type BridgeTransaction,
   ASSET_XLM,
   NETWORK_DISPLAY,
   DEFAULT_TX_LIMIT,
@@ -20,7 +22,8 @@ import {
   STATUS_PENDING,
   ENV_BRIDGE_CONTRACT_ID,
   USDC_ISSUERS,
-} from "@/lib/constants";
+} from "@/lib";
+import { getBridgeContractId } from "@/config/networks";
 
 export default function DashboardPage() {
   const { isConnected, address, network, connect } = useWallet();

--- a/src/app/onramp/page.tsx
+++ b/src/app/onramp/page.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from "react";
 import { CreditCard, Wallet, ExternalLink, ArrowRight, Check, DollarSign, AlertCircle } from "lucide-react";
-import { isValidStellarAddress, isCAddress } from "@/lib/stellar";
 import { validateCAddress } from "@/utils/validation";
 import {
+  isValidStellarAddress,
+  isCAddress,
+  estimateOnrampOutput,
   STELLAR_ADDRESS_LENGTH,
   PROVIDER_MOONPAY,
   PROVIDER_TRANSAK,
@@ -18,8 +20,7 @@ import {
   ENV_TRANSAK_API_KEY,
   STEP_FORM,
   STEP_REDIRECT,
-} from "@/lib/constants";
-import { estimateOnrampOutput } from "@/lib/onramp";
+} from "@/lib";
 
 const MOONPAY_API_KEY = process.env.NEXT_PUBLIC_MOONPAY_API_KEY || "";
 const TRANSAK_API_KEY = process.env.NEXT_PUBLIC_TRANSAK_API_KEY || "";

--- a/src/components/cex-address-verification.tsx
+++ b/src/components/cex-address-verification.tsx
@@ -9,8 +9,8 @@ import {
   getChallenge,
   clearChallenge,
   type VerificationChallenge,
-} from "@/lib/cex-verification";
-import { DEFAULT_BRIDGE_ADDRESS } from "@/lib/types";
+  DEFAULT_BRIDGE_ADDRESS,
+} from "@/lib";
 
 export interface CEXVerificationProps {
   onVerified: () => void;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Public API barrel for src/components/.
+ *
+ * Re-exports every component and hook that external callers (app pages,
+ * tests) may need. Files that only have default exports use the
+ * `export { default as X }` form so consumers get named imports everywhere.
+ */
+
+// ─── CEX address verification ─────────────────────────────────────────────────
+export type { CEXVerificationProps } from "./cex-address-verification";
+export { CEXAddressVerification } from "./cex-address-verification";
+
+// ─── Generic data table ───────────────────────────────────────────────────────
+export type { Column, DataTableProps } from "./data-table";
+export { DataTable } from "./data-table";
+
+// ─── Fee selector ─────────────────────────────────────────────────────────────
+export type { FeeTier } from "./fee-selector";
+export { FeeSelector } from "./fee-selector";
+
+// ─── Footer ───────────────────────────────────────────────────────────────────
+export { default as Footer } from "./footer";
+
+// ─── Keyboard shortcuts info panel ───────────────────────────────────────────
+export { KeyboardShortcutsInfo } from "./keyboard-shortcuts-info";
+
+// ─── Navigation bar ───────────────────────────────────────────────────────────
+export { default as Navbar } from "./navbar";
+
+// ─── Network mismatch banner ─────────────────────────────────────────────────
+export { NetworkMismatchBanner } from "./network-mismatch-banner";
+
+// ─── Onboarding tour ─────────────────────────────────────────────────────────
+export { default as OnboardingTour, useOnboardingTour } from "./onboarding-tour";
+
+// ─── Resource / simulation result panel ──────────────────────────────────────
+export { ResourcePanel } from "./resource-panel";
+
+// ─── Theme provider and hook ─────────────────────────────────────────────────
+export { ThemeProvider, useTheme } from "./theme-provider";
+
+// ─── Theme toggle button ─────────────────────────────────────────────────────
+export { ThemeToggle } from "./theme-toggle";
+
+// ─── Toast notifications ─────────────────────────────────────────────────────
+export type { ToastType, Toast } from "./toast";
+export { ToastContainer, useToast } from "./toast";
+
+// ─── Tour provider ────────────────────────────────────────────────────────────
+export { default as TourProvider } from "./tour-provider";
+
+// ─── Transaction history table ────────────────────────────────────────────────
+export { default as TransactionHistory } from "./transaction-history";
+
+// ─── Wallet modal ─────────────────────────────────────────────────────────────
+export { default as WalletModal } from "./wallet-modal";
+
+// ─── Wallet permissions panel ────────────────────────────────────────────────
+export { WalletPermissionsPanel } from "./wallet-permissions-panel";
+
+// ─── Wallet provider and hook ─────────────────────────────────────────────────
+export { WalletProvider, useWallet } from "./wallet-provider";

--- a/src/components/transaction-history.tsx
+++ b/src/components/transaction-history.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { ArrowLeftRight, CreditCard, Building2, ExternalLink } from "lucide-react";
-import type { BridgeTransaction as BridgeTransactionData } from "@/lib/types";
-import { getExplorerUrl } from "@/lib/stellar";
-import { EXPLORER_BASE_URLS } from "@/lib/constants";
+import { type BridgeTransaction as BridgeTransactionData, getExplorerUrl, EXPLORER_BASE_URLS } from "@/lib";
 
 const typeConfig: Record<string, { icon: typeof ArrowLeftRight; label: string; color: string }> = {
   "g-to-c": { icon: ArrowLeftRight, label: "G → C Bridge", color: "text-[var(--primary-light)]" },

--- a/src/components/wallet-provider.tsx
+++ b/src/components/wallet-provider.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react";
-import { connectWallet, checkConnection, getWalletAddress, getCurrentNetwork } from "@/lib/stellar";
-import { WALLET_INITIAL_DELAY_MS, WALLET_POLL_INTERVAL_MS, DEFAULT_NETWORK } from "@/lib/constants";
+import {
+  connectWallet,
+  checkConnection,
+  getWalletAddress,
+  getCurrentNetwork,
+  WALLET_INITIAL_DELAY_MS,
+  WALLET_POLL_INTERVAL_MS,
+  DEFAULT_NETWORK,
+} from "@/lib";
 
 const APP_NETWORK_KEY = "stellar_app_network";
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,13 @@
+/**
+ * Next.js instrumentation hook — runs once on server startup before any
+ * requests are handled. We use it to fail fast on env misconfiguration rather
+ * than surfacing cryptic errors at request time.
+ */
+export async function register() {
+  // Only validate on the server; NEXT_PUBLIC_* vars are also available in the
+  // browser, but startup validation belongs to the server process.
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { validateEnv } = await import("./lib/env");
+    validateEnv();
+  }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,91 @@
+export interface AppEnv {
+  stellarNetwork: "PUBLIC" | "TESTNET";
+  bridgeContractIdTestnet: string;
+  bridgeContractIdMainnet: string;
+  bridgeContractIdFuturenet: string;
+  /** Legacy single-network contract ID; prefer per-network vars. */
+  bridgeContractId: string;
+  moonpayApiKey: string;
+  transakApiKey: string;
+}
+
+interface EnvError {
+  key: string;
+  message: string;
+}
+
+function isContractAddress(value: string): boolean {
+  return /^C[A-Z0-9]{55}$/.test(value);
+}
+
+let _env: AppEnv | undefined;
+
+/**
+ * Validates all NEXT_PUBLIC_* environment variables and returns a typed env
+ * object. Throws with a descriptive list of all failures on misconfiguration.
+ * Subsequent calls return the cached result without re-validating.
+ */
+export function validateEnv(): AppEnv {
+  if (_env) return _env;
+
+  const errors: EnvError[] = [];
+
+  // NEXT_PUBLIC_STELLAR_NETWORK — optional, must be PUBLIC or TESTNET if set
+  const rawNetwork = process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+  let stellarNetwork: "PUBLIC" | "TESTNET" = "TESTNET";
+  if (rawNetwork !== undefined && rawNetwork !== "") {
+    const upper = rawNetwork.toUpperCase();
+    if (upper !== "PUBLIC" && upper !== "TESTNET") {
+      errors.push({
+        key: "NEXT_PUBLIC_STELLAR_NETWORK",
+        message: `must be "PUBLIC" or "TESTNET", got "${rawNetwork}"`,
+      });
+    } else {
+      stellarNetwork = upper as "PUBLIC" | "TESTNET";
+    }
+  }
+
+  // Contract ID vars — optional, but must be valid C-addresses if provided
+  const contractVars = [
+    "NEXT_PUBLIC_BRIDGE_CONTRACT_ID_TESTNET",
+    "NEXT_PUBLIC_BRIDGE_CONTRACT_ID_MAINNET",
+    "NEXT_PUBLIC_BRIDGE_CONTRACT_ID_FUTURENET",
+    "NEXT_PUBLIC_BRIDGE_CONTRACT_ID",
+  ] as const;
+
+  for (const key of contractVars) {
+    const value = process.env[key];
+    if (value && !isContractAddress(value)) {
+      errors.push({
+        key,
+        message: `must be a valid C-address (56 chars, starts with "C"), got "${value}"`,
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    const details = errors.map((e) => `  • ${e.key}: ${e.message}`).join("\n");
+    throw new Error(`Environment configuration error(s):\n${details}`);
+  }
+
+  _env = {
+    stellarNetwork,
+    bridgeContractIdTestnet: process.env.NEXT_PUBLIC_BRIDGE_CONTRACT_ID_TESTNET ?? "",
+    bridgeContractIdMainnet: process.env.NEXT_PUBLIC_BRIDGE_CONTRACT_ID_MAINNET ?? "",
+    bridgeContractIdFuturenet: process.env.NEXT_PUBLIC_BRIDGE_CONTRACT_ID_FUTURENET ?? "",
+    bridgeContractId: process.env.NEXT_PUBLIC_BRIDGE_CONTRACT_ID ?? "",
+    moonpayApiKey: process.env.NEXT_PUBLIC_MOONPAY_API_KEY ?? "",
+    transakApiKey: process.env.NEXT_PUBLIC_TRANSAK_API_KEY ?? "",
+  };
+
+  return _env;
+}
+
+/**
+ * Returns the validated env singleton. Validates on first call; subsequent
+ * calls are effectively free. Prefer importing this over process.env directly
+ * so callers get full type inference.
+ */
+export function getEnv(): AppEnv {
+  return validateEnv();
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Public API barrel for src/lib/.
+ *
+ * Files within lib/ import each other via relative paths to avoid circular
+ * dependencies. This barrel is for consumers outside lib/ (app pages,
+ * components, services).
+ *
+ * env.ts is intentionally excluded — import it directly from "@/lib/env" so
+ * the intent is explicit and tree-shaking stays clean.
+ *
+ * use-fee-stats.ts is intentionally excluded from this barrel because it
+ * carries a "use client" directive. Import it directly from
+ * "@/lib/use-fee-stats" inside client components.
+ */
+
+// ─── Core types (items not re-exported by stellar.ts) ────────────────────────
+export type {
+  AddressType,
+  WalletState,
+  BridgeTransaction,
+  Balance,
+  OnrampQuote,
+  CexConfig,
+} from "./types";
+export {
+  STELLAR_NETWORK,
+  SOROBAN_RPC_URL,
+  HORIZON_URL,
+  BRIDGE_CONTRACT_ID,
+  DEFAULT_BRIDGE_ADDRESS,
+  DEFAULT_BRIDGE_MEMO,
+  CEX_LIST,
+  getBridgeContractId,
+  BRIDGE_CONTRACT_IDS,
+} from "./types";
+
+// ─── Stellar / Soroban interactions ──────────────────────────────────────────
+// Also re-exports: PaymentResult, AccountBalances, BridgeTransactionData (from types)
+export * from "./stellar";
+
+// ─── App-wide constants ───────────────────────────────────────────────────────
+export * from "./constants";
+
+// ─── CEX withdrawal verification ─────────────────────────────────────────────
+export * from "./cex-verification";
+
+// ─── Freighter wallet capability management ───────────────────────────────────
+export * from "./freighter-capabilities";
+
+// ─── Mempool duplicate detection ─────────────────────────────────────────────
+export * from "./mempool-detection";
+
+// ─── Fiat onramp estimation ───────────────────────────────────────────────────
+export * from "./onramp";
+
+// ─── Rate limiting and submission deduplication ───────────────────────────────
+export * from "./rate-limit";
+
+// ─── Input sanitization ───────────────────────────────────────────────────────
+export * from "./sanitization";
+
+// ─── Encrypted local storage ──────────────────────────────────────────────────
+export * from "./secure-storage";
+
+// ─── Transaction simulation ───────────────────────────────────────────────────
+export * from "./transaction-simulation";
+
+// ─── Encrypted user preferences ──────────────────────────────────────────────
+export * from "./user-preferences";


### PR DESCRIPTION
- Create src/lib/index.ts and src/components/index.ts barrel files that re-export all public API surfaces, giving consumers a single clean import path (@/lib, @/components) instead of deep sub-module paths.

- Create src/lib/env.ts with validateEnv() / getEnv(): validates all NEXT_PUBLIC_* env vars at startup, throws with a descriptive error listing every invalid value, and returns a typed AppEnv object so the rest of the app gets full autocompletion instead of raw process.env string access.

- Add src/instrumentation.ts to call validateEnv() in the Next.js server startup hook, surfacing misconfiguration before the first request.

- Update 7 files (app pages + components) to use barrel imports where they previously scattered imports across multiple @/lib/* or @/components/* subpaths.

use-fee-stats.ts and env.ts are intentionally excluded from the lib barrel to avoid "use client" boundary issues and to keep env validation intent explicit respectively.

closes #13 
closes #14 