### PR TITLE
feat: graceful Stellar SDK version handling (#93)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      stellar-sdk:
+        patterns:
+          - "@stellar/*"
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+          - "playwright"
+          - "@playwright/*"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore"
+      include: scope
+    ignore:
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,42 @@ E2E tests (requires a running dev server or built app):
 npm run test:e2e
 ```
 
+## Upgrading the Stellar SDK
+
+The `@stellar/stellar-sdk` and `@stellar/freighter-api` versions are pinned exactly in `package.json` (no `^` caret). This is intentional — the Stellar SDK moves fast and caret ranges have caused silent breakage in the past.
+
+Dependabot is configured to open a PR when a new version is available. Before merging any SDK upgrade PR:
+
+### Upgrade checklist
+
+1. Read the SDK release notes / changelog for breaking changes.
+2. Run the full check suite locally:
+   ```bash
+   npm run typecheck
+   npm run test
+   npm run build
+   ```
+3. Pay special attention to the integration test suite:
+   ```bash
+   npx vitest run src/__tests__/stellar-sdk-integration.test.ts
+   ```
+   These tests validate the behaviour the abstraction layer depends on. A failure here means `src/lib/stellar-sdk.ts` needs to be updated before the upgrade is safe to merge.
+4. Check `src/lib/stellar-sdk.ts` for any API surface that changed. The abstraction layer exports wrappers for the most version-sensitive areas:
+   - `isSimulationError` / `getSimulationMinFee` / `getSimulationRetval` — Soroban RPC response shape
+   - `checkFreighterConnection` / `getFreighterAddress` / `getFreighterNetwork` / `signWithFreighter` — Freighter API return shapes
+   - `createHorizonServer` / `createSorobanServer` — server construction
+   - `transactionFromXDR` / `addressFromString` — transaction and address helpers
+5. Update the version pins in `package.json` to the new exact version.
+6. Run `npm install` to update `package-lock.json`, then commit both files together.
+7. Do not merge if any check fails.
+
+### Adding new SDK calls
+
+When adding new code that calls the Stellar SDK directly:
+- Import from `@/lib/stellar-sdk`, not from `@stellar/stellar-sdk` or `@stellar/freighter-api`.
+- If the SDK functionality you need is not yet exported by `stellar-sdk.ts`, add a thin wrapper there first.
+- Add a test in `src/__tests__/stellar-sdk-integration.test.ts` that covers the new wrapper's behaviour, including its response-shape assumptions.
+
 ## Submitting a Pull Request
 
 1. Branch off `main`: `git checkout -b feat/short-description`

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@stellar/freighter-api": "^6.0.1",
-    "@stellar/stellar-sdk": "^15.1.0",
+    "@stellar/freighter-api": "6.0.1",
+    "@stellar/stellar-sdk": "15.1.0",
     "lucide-react": "^1.17.0",
     "next": "16.2.7",
     "react": "19.2.4",

--- a/src/__tests__/stellar-sdk-integration.test.ts
+++ b/src/__tests__/stellar-sdk-integration.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Integration tests that validate Stellar SDK behaviour through the
+ * abstraction layer (src/lib/stellar-sdk.ts).
+ *
+ * These tests serve as a regression suite for SDK version upgrades.
+ * If an SDK bump breaks any of these, the abstraction layer in
+ * stellar-sdk.ts must be updated before the upgrade is merged.
+ *
+ * Coverage areas:
+ *  - Server factory functions return the right types
+ *  - Simulation response helpers handle success and error shapes
+ *  - Address utilities accept/reject the right input
+ *  - Transaction XDR round-trip via transactionFromXDR
+ *  - Freighter wrapper functions translate return shapes correctly
+ *  - networkPassphrase returns the correct constants
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Freighter mock ────────────────────────────────────────────────────────────
+vi.mock("@stellar/freighter-api", () => ({
+  isConnected: vi.fn(),
+  getAddress: vi.fn(),
+  getNetwork: vi.fn(),
+  signTransaction: vi.fn(),
+}));
+
+import { isConnected, getAddress, getNetwork, signTransaction } from "@stellar/freighter-api";
+
+import {
+  createHorizonServer,
+  createSorobanServer,
+  isSimulationError,
+  getSimulationMinFee,
+  getSimulationRetval,
+  isValidAddress,
+  isValidContractAddress,
+  addressFromString,
+  transactionFromXDR,
+  checkFreighterConnection,
+  getFreighterAddress,
+  getFreighterNetwork,
+  signWithFreighter,
+  networkPassphrase,
+  Networks,
+  rpc,
+  Horizon,
+  StrKey,
+  BASE_FEE,
+} from "@/lib/stellar-sdk";
+
+// ── Server factory tests ──────────────────────────────────────────────────────
+
+describe("createHorizonServer", () => {
+  it("returns a Horizon.Server instance", () => {
+    const server = createHorizonServer("https://horizon-testnet.stellar.org");
+    expect(server).toBeInstanceOf(Horizon.Server);
+  });
+
+  it("constructs separate instances for different URLs", () => {
+    const a = createHorizonServer("https://horizon-testnet.stellar.org");
+    const b = createHorizonServer("https://horizon.stellar.org");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("createSorobanServer", () => {
+  it("returns an rpc.Server instance", () => {
+    const server = createSorobanServer("https://soroban-testnet.stellar.org");
+    expect(server).toBeInstanceOf(rpc.Server);
+  });
+});
+
+// ── Simulation helpers ────────────────────────────────────────────────────────
+
+describe("isSimulationError", () => {
+  it("returns true for error responses", () => {
+    const errorSim = { error: "Some error", events: [], latestLedger: 1 } as unknown as rpc.Api.SimulateTransactionResponse;
+    expect(isSimulationError(errorSim)).toBe(true);
+  });
+
+  it("returns false for success responses", () => {
+    const successSim = {
+      minResourceFee: "100",
+      results: [],
+      transactionData: {},
+      events: [],
+      latestLedger: 1,
+    } as unknown as rpc.Api.SimulateTransactionResponse;
+    expect(isSimulationError(successSim)).toBe(false);
+  });
+});
+
+describe("getSimulationMinFee", () => {
+  it("returns the fee as a string when present", () => {
+    const sim = { minResourceFee: "12345" } as unknown as rpc.Api.SimulateTransactionSuccessResponse;
+    expect(getSimulationMinFee(sim)).toBe("12345");
+  });
+
+  it("returns null when minResourceFee is absent", () => {
+    const sim = {} as rpc.Api.SimulateTransactionSuccessResponse;
+    expect(getSimulationMinFee(sim)).toBeNull();
+  });
+});
+
+describe("getSimulationRetval", () => {
+  it("returns retval when result is present", () => {
+    const mockScVal = { switch: () => ({}) };
+    const sim = {
+      result: { retval: mockScVal },
+    } as unknown as rpc.Api.SimulateTransactionSuccessResponse;
+    expect(getSimulationRetval(sim)).toBe(mockScVal);
+  });
+
+  it("returns null when result is absent", () => {
+    const sim = {} as rpc.Api.SimulateTransactionSuccessResponse;
+    expect(getSimulationRetval(sim)).toBeNull();
+  });
+
+  it("returns null when retval is absent", () => {
+    const sim = { result: {} } as unknown as rpc.Api.SimulateTransactionSuccessResponse;
+    expect(getSimulationRetval(sim)).toBeNull();
+  });
+});
+
+// ── Address utilities ─────────────────────────────────────────────────────────
+
+const VALID_G = "GAIUIQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5A";
+const VALID_C = "CAIUIQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5A";
+
+describe("isValidAddress", () => {
+  it("accepts a valid G-address", () => {
+    expect(isValidAddress(VALID_G)).toBe(true);
+  });
+
+  it("accepts a valid C-address", () => {
+    expect(isValidAddress(VALID_C)).toBe(true);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isValidAddress("")).toBe(false);
+  });
+
+  it("rejects a truncated address", () => {
+    expect(isValidAddress("GABC")).toBe(false);
+  });
+
+  it("rejects a random string", () => {
+    expect(isValidAddress("not-an-address")).toBe(false);
+  });
+});
+
+describe("isValidContractAddress", () => {
+  it("accepts a valid C-address", () => {
+    expect(isValidContractAddress(VALID_C)).toBe(true);
+  });
+
+  it("rejects a G-address", () => {
+    expect(isValidContractAddress(VALID_G)).toBe(false);
+  });
+
+  it("rejects garbage input", () => {
+    expect(isValidContractAddress("garbage")).toBe(false);
+  });
+});
+
+describe("addressFromString", () => {
+  it("returns an Address for a valid G-address", () => {
+    const addr = addressFromString(VALID_G);
+    expect(addr).toBeDefined();
+    expect(addr.toString()).toBe(VALID_G);
+  });
+
+  it("returns an Address for a valid C-address", () => {
+    const addr = addressFromString(VALID_C);
+    expect(addr).toBeDefined();
+    expect(addr.toString()).toBe(VALID_C);
+  });
+});
+
+// ── Network passphrase ────────────────────────────────────────────────────────
+
+describe("networkPassphrase", () => {
+  it("returns the PUBLIC passphrase for PUBLIC", () => {
+    expect(networkPassphrase("PUBLIC")).toBe(Networks.PUBLIC);
+  });
+
+  it("returns the TESTNET passphrase for TESTNET", () => {
+    expect(networkPassphrase("TESTNET")).toBe(Networks.TESTNET);
+  });
+
+  it("PUBLIC and TESTNET passphrases are different strings", () => {
+    expect(networkPassphrase("PUBLIC")).not.toBe(networkPassphrase("TESTNET"));
+  });
+});
+
+// ── Freighter wrappers ────────────────────────────────────────────────────────
+
+describe("checkFreighterConnection", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns isConnected: true when Freighter is connected", async () => {
+    vi.mocked(isConnected).mockResolvedValueOnce({ isConnected: true });
+    const result = await checkFreighterConnection();
+    expect(result.isConnected).toBe(true);
+  });
+
+  it("returns isConnected: false when Freighter is not connected", async () => {
+    vi.mocked(isConnected).mockResolvedValueOnce({ isConnected: false });
+    const result = await checkFreighterConnection();
+    expect(result.isConnected).toBe(false);
+  });
+
+  it("returns isConnected: false on error", async () => {
+    vi.mocked(isConnected).mockRejectedValueOnce(new Error("no extension"));
+    const result = await checkFreighterConnection();
+    expect(result.isConnected).toBe(false);
+  });
+});
+
+describe("getFreighterAddress", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the address string on success", async () => {
+    vi.mocked(getAddress).mockResolvedValueOnce({ address: VALID_G });
+    expect(await getFreighterAddress()).toBe(VALID_G);
+  });
+
+  it("returns null on error", async () => {
+    vi.mocked(getAddress).mockRejectedValueOnce(new Error("fail"));
+    expect(await getFreighterAddress()).toBeNull();
+  });
+
+  it("returns null when address is empty", async () => {
+    vi.mocked(getAddress).mockResolvedValueOnce({ address: "" });
+    expect(await getFreighterAddress()).toBeNull();
+  });
+});
+
+describe("getFreighterNetwork", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns PUBLIC when Freighter is on mainnet", async () => {
+    vi.mocked(getNetwork).mockResolvedValueOnce({ network: Networks.PUBLIC, networkPassphrase: Networks.PUBLIC });
+    expect(await getFreighterNetwork()).toBe("PUBLIC");
+  });
+
+  it("returns TESTNET when Freighter is on testnet", async () => {
+    vi.mocked(getNetwork).mockResolvedValueOnce({ network: Networks.TESTNET, networkPassphrase: Networks.TESTNET });
+    expect(await getFreighterNetwork()).toBe("TESTNET");
+  });
+
+  it("defaults to TESTNET on error", async () => {
+    vi.mocked(getNetwork).mockRejectedValueOnce(new Error("fail"));
+    expect(await getFreighterNetwork()).toBe("TESTNET");
+  });
+});
+
+describe("signWithFreighter", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns signedTxXdr on success", async () => {
+    vi.mocked(signTransaction).mockResolvedValueOnce({ signedTxXdr: "signed-xdr-value" });
+    const result = await signWithFreighter("mock-xdr", Networks.TESTNET);
+    expect(result.signedTxXdr).toBe("signed-xdr-value");
+  });
+
+  it("throws when Freighter returns an error", async () => {
+    vi.mocked(signTransaction).mockResolvedValueOnce({ error: "User rejected" } as never);
+    await expect(signWithFreighter("mock-xdr", Networks.TESTNET)).rejects.toThrow(
+      "Freighter signing failed: User rejected"
+    );
+  });
+});
+
+// ── Constants exposed by the abstraction layer ────────────────────────────────
+
+describe("SDK constants re-exported correctly", () => {
+  it("BASE_FEE is a non-empty string", () => {
+    expect(typeof BASE_FEE).toBe("string");
+    expect(BASE_FEE.length).toBeGreaterThan(0);
+  });
+
+  it("Networks.PUBLIC is a non-empty string", () => {
+    expect(typeof Networks.PUBLIC).toBe("string");
+    expect(Networks.PUBLIC.length).toBeGreaterThan(0);
+  });
+
+  it("Networks.TESTNET is a non-empty string", () => {
+    expect(typeof Networks.TESTNET).toBe("string");
+    expect(Networks.TESTNET.length).toBeGreaterThan(0);
+  });
+
+  it("StrKey is exported and functional", () => {
+    expect(typeof StrKey.isValidEd25519PublicKey).toBe("function");
+    expect(StrKey.isValidEd25519PublicKey(VALID_G)).toBe(true);
+  });
+});

--- a/src/lib/horizon-stream.ts
+++ b/src/lib/horizon-stream.ts
@@ -13,7 +13,7 @@
  * MUST invoke on unmount to prevent memory leaks.
  */
 
-import { Horizon } from "@stellar/stellar-sdk";
+import { Horizon } from "./stellar-sdk";
 import { HORIZON_URL } from "./types";
 
 export interface StreamPaymentRecord {

--- a/src/lib/stellar-sdk.ts
+++ b/src/lib/stellar-sdk.ts
@@ -1,0 +1,213 @@
+/**
+ * Abstraction layer over @stellar/stellar-sdk and @stellar/freighter-api.
+ *
+ * All SDK imports used by the application must flow through this module.
+ * This minimises the surface area that breaks when the SDK is upgraded:
+ * only this file needs to change; the rest of the codebase stays stable.
+ *
+ * Version compatibility: @stellar/stellar-sdk 15.x, @stellar/freighter-api 6.x
+ */
+
+import {
+  TransactionBuilder,
+  Operation,
+  Asset,
+  Contract,
+  Address,
+  Account,
+  Networks,
+  BASE_FEE,
+  StrKey,
+  Horizon,
+  rpc,
+  nativeToScVal,
+  scValToNative,
+} from "@stellar/stellar-sdk";
+import type { Transaction, FeeBumpTransaction, xdr } from "@stellar/stellar-sdk";
+import {
+  isConnected as freighterIsConnected,
+  getAddress as freighterGetAddress,
+  getNetwork as freighterGetNetwork,
+  signTransaction as freighterSignTransaction,
+} from "@stellar/freighter-api";
+
+// ── Re-export SDK primitives ──────────────────────────────────────────────────
+// Components and lib modules import from here, never from @stellar/* directly.
+
+export {
+  TransactionBuilder,
+  Operation,
+  Asset,
+  Contract,
+  Address,
+  Account,
+  Networks,
+  BASE_FEE,
+  StrKey,
+  Horizon,
+  rpc,
+  nativeToScVal,
+  scValToNative,
+};
+export type { Transaction, FeeBumpTransaction, xdr };
+
+// ── Horizon ───────────────────────────────────────────────────────────────────
+
+/**
+ * Create a Horizon HTTP client for the given network.
+ * Centralising construction here means a URL or constructor change only
+ * requires editing this one function.
+ */
+export function createHorizonServer(baseUrl: string): Horizon.Server {
+  return new Horizon.Server(baseUrl);
+}
+
+// ── Soroban RPC ───────────────────────────────────────────────────────────────
+
+/**
+ * Create a Soroban RPC client for the given network.
+ */
+export function createSorobanServer(baseUrl: string): rpc.Server {
+  return new rpc.Server(baseUrl);
+}
+
+// ── Simulation helpers ────────────────────────────────────────────────────────
+
+/**
+ * Type-safe wrapper that checks whether a simulation response is an error.
+ * Isolates the rpc.Api.isSimulationError call so callers are shielded from
+ * type-shape changes in new SDK versions.
+ */
+export function isSimulationError(
+  sim: rpc.Api.SimulateTransactionResponse
+): sim is rpc.Api.SimulateTransactionErrorResponse {
+  return rpc.Api.isSimulationError(sim);
+}
+
+/**
+ * Extract the min resource fee from a successful simulation response.
+ * Returns null when the field is absent (version-safe default).
+ */
+export function getSimulationMinFee(
+  sim: rpc.Api.SimulateTransactionSuccessResponse
+): string | null {
+  const fee = sim.minResourceFee;
+  return fee != null ? String(fee) : null;
+}
+
+/**
+ * Extract the return value ScVal from a successful simulation response.
+ * Returns null when the field is absent (version-safe default).
+ */
+export function getSimulationRetval(
+  sim: rpc.Api.SimulateTransactionSuccessResponse
+): xdr.ScVal | null {
+  return sim.result?.retval ?? null;
+}
+
+// ── Freighter API wrappers ────────────────────────────────────────────────────
+// Thin wrappers that translate Freighter's return shapes into plain values,
+// so callers don't need to know the exact response shape for each SDK version.
+
+export interface FreighterConnectionResult {
+  isConnected: boolean;
+}
+
+export async function checkFreighterConnection(): Promise<FreighterConnectionResult> {
+  try {
+    const result = await freighterIsConnected();
+    return { isConnected: result.isConnected };
+  } catch {
+    return { isConnected: false };
+  }
+}
+
+export async function getFreighterAddress(): Promise<string | null> {
+  try {
+    const result = await freighterGetAddress();
+    return result.address || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getFreighterNetwork(): Promise<"PUBLIC" | "TESTNET"> {
+  try {
+    const result = await freighterGetNetwork();
+    return result.network === Networks.PUBLIC ? "PUBLIC" : "TESTNET";
+  } catch {
+    return "TESTNET";
+  }
+}
+
+export interface FreighterSignResult {
+  signedTxXdr: string;
+}
+
+export async function signWithFreighter(
+  xdrStr: string,
+  networkPassphrase: string
+): Promise<FreighterSignResult> {
+  const result = await freighterSignTransaction(xdrStr, { networkPassphrase });
+  if ("error" in result && result.error) {
+    throw new Error(`Freighter signing failed: ${result.error}`);
+  }
+  return { signedTxXdr: (result as { signedTxXdr: string }).signedTxXdr };
+}
+
+// ── Address utilities ─────────────────────────────────────────────────────────
+
+/**
+ * Validate a Stellar address using the SDK's StrKey utilities.
+ * Handles both G-addresses (Ed25519 public keys) and C-addresses (contract IDs).
+ */
+export function isValidAddress(address: string): boolean {
+  if (!address) return false;
+  try {
+    return (
+      StrKey.isValidEd25519PublicKey(address) ||
+      isValidContractAddress(address)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isValidContractAddress(address: string): boolean {
+  try {
+    StrKey.decodeContract(address);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Convert an account or contract address string to an Address instance.
+ */
+export function addressFromString(address: string): Address {
+  if (address.startsWith("C")) {
+    return Address.contract(StrKey.decodeContract(address));
+  }
+  return Address.account(StrKey.decodeEd25519PublicKey(address));
+}
+
+// ── Transaction helpers ───────────────────────────────────────────────────────
+
+/**
+ * Decode an XDR envelope back to a Transaction or FeeBumpTransaction.
+ * Wraps TransactionBuilder.fromXDR so callers are isolated from signature
+ * changes in future SDK versions.
+ */
+export function transactionFromXDR(
+  xdrStr: string,
+  networkPassphrase: string
+): Transaction | FeeBumpTransaction {
+  return TransactionBuilder.fromXDR(xdrStr, networkPassphrase);
+}
+
+// ── Network passphrase helper ─────────────────────────────────────────────────
+
+export function networkPassphrase(network: "PUBLIC" | "TESTNET"): string {
+  return network === "PUBLIC" ? Networks.PUBLIC : Networks.TESTNET;
+}

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -1,25 +1,4 @@
 import {
-  isConnected,
-  getAddress,
-  signTransaction as freighterSignTransaction,
-  getNetwork,
-} from "@stellar/freighter-api";
-
-/**
- * Wallet-agnostic signer function.  Matches the signature of each
- * WalletAdapter.signTransaction so callers can pass any adapter's signer
- * instead of being hard-wired to Freighter.
- * Falls back to Freighter when omitted.
- */
-export type TxSigner = (xdr: string, networkPassphrase: string) => Promise<string>;
-
-/** Default signer — wraps Freighter's API into the TxSigner shape. */
-async function defaultSigner(xdr: string, networkPassphrase: string): Promise<string> {
-  const result = await freighterSignTransaction(xdr, { networkPassphrase });
-  if ("error" in result && result.error) throw new Error(`Freighter signing failed: ${result.error}`);
-  return (result as { signedTxXdr: string }).signedTxXdr;
-}
-import {
   TransactionBuilder,
   Operation,
   BASE_FEE,
@@ -33,7 +12,31 @@ import {
   nativeToScVal,
   scValToNative,
   StrKey,
-} from "@stellar/stellar-sdk";
+  checkFreighterConnection,
+  getFreighterAddress,
+  getFreighterNetwork,
+  signWithFreighter,
+  isSimulationError,
+  getSimulationRetval,
+  addressFromString,
+  transactionFromXDR,
+  createHorizonServer,
+  createSorobanServer,
+} from "./stellar-sdk";
+
+/**
+ * Wallet-agnostic signer function.  Matches the signature of each
+ * WalletAdapter.signTransaction so callers can pass any adapter's signer
+ * instead of being hard-wired to Freighter.
+ * Falls back to Freighter when omitted.
+ */
+export type TxSigner = (xdr: string, networkPassphrase: string) => Promise<string>;
+
+/** Default signer — wraps Freighter via the SDK abstraction layer. */
+async function defaultSigner(xdr: string, passphrase: string): Promise<string> {
+  const result = await signWithFreighter(xdr, passphrase);
+  return result.signedTxXdr;
+}
 import {
   BRIDGE_CONTRACT_ID,
   HORIZON_URL,
@@ -78,7 +81,7 @@ export type { PaymentResult, AccountBalances } from "./types";
  * const account = await server.loadAccount("G...");
  */
 export function getHorizonServer(network: "PUBLIC" | "TESTNET"): Horizon.Server {
-  return new Horizon.Server(HORIZON_URL[network]);
+  return createHorizonServer(HORIZON_URL[network]);
 }
 
 /**
@@ -92,7 +95,7 @@ export function getHorizonServer(network: "PUBLIC" | "TESTNET"): Horizon.Server 
  * const account = await rpcServer.getAccount("G...");
  */
 export function getSorobanRpcServer(network: "PUBLIC" | "TESTNET"): rpc.Server {
-  return new rpc.Server(SOROBAN_RPC_URL[network]);
+  return createSorobanServer(SOROBAN_RPC_URL[network]);
 }
 
 /**
@@ -118,12 +121,12 @@ export function getNetworkPassphrase(network: "PUBLIC" | "TESTNET"): string {
  */
 export async function connectWallet(): Promise<string | null> {
   try {
-    const conn = await isConnected();
+    const conn = await checkFreighterConnection();
     if (!conn.isConnected) {
       throw new Error("Freighter not detected");
     }
-    const addr = await getAddress();
-    return addr.address;
+    const addr = await getFreighterAddress();
+    return addr;
   } catch (e) {
     console.error("Failed to connect wallet:", e);
     return null;
@@ -137,7 +140,7 @@ export async function connectWallet(): Promise<string | null> {
  */
 export async function checkConnection(): Promise<boolean> {
   try {
-    const result = await isConnected();
+    const result = await checkFreighterConnection();
     return result.isConnected;
   } catch {
     return false;
@@ -150,12 +153,7 @@ export async function checkConnection(): Promise<boolean> {
  * @returns The G-address string, or `null` if Freighter is unavailable.
  */
 export async function getWalletAddress(): Promise<string | null> {
-  try {
-    const result = await getAddress();
-    return result.address;
-  } catch {
-    return null;
-  }
+  return getFreighterAddress();
 }
 
 /**
@@ -164,13 +162,7 @@ export async function getWalletAddress(): Promise<string | null> {
  * @returns `"PUBLIC"` or `"TESTNET"`. Falls back to the app default if Freighter is unavailable.
  */
 export async function getCurrentNetwork(): Promise<"PUBLIC" | "TESTNET"> {
-  try {
-    const result = await getNetwork();
-    return result.network === Networks.PUBLIC ? "PUBLIC" : "TESTNET";
-  } catch {
-    return DEFAULT_NETWORK;
-  }
-}
+  return getFreighterNetwork();
 
 /**
  * Returns `true` if the given string is a syntactically valid Stellar address (G- or C-address).
@@ -366,7 +358,7 @@ export async function buildAndSubmitPayment(
     .build();
 
   const signedXDR = await signer(tx.toXDR(), passphrase);
-  const signedTx = TransactionBuilder.fromXDR(signedXDR, passphrase);
+  const signedTx = transactionFromXDR(signedXDR, passphrase);
   const result = await server.submitTransaction(signedTx);
   return { hash: result.hash, successful: result.successful };
 }
@@ -468,7 +460,7 @@ export async function bridgeViaContract(
   }
 
   const signedXDR = await signer(prepared.toXDR(), passphrase);
-  const signedTx = TransactionBuilder.fromXDR(signedXDR, passphrase);
+  const signedTx = transactionFromXDR(signedXDR, passphrase);
 
   const sendResult = await server.sendTransaction(signedTx);
   if (sendResult.status === "ERROR") {
@@ -609,7 +601,7 @@ export async function buildAndSubmitChangeTrust(
     .build();
 
   const signedXDR = await signer(tx.toXDR(), passphrase);
-  const signedTx = TransactionBuilder.fromXDR(signedXDR, passphrase);
+  const signedTx = transactionFromXDR(signedXDR, passphrase);
   const result = await server.submitTransaction(signedTx);
   return { hash: result.hash, successful: result.successful };
 }
@@ -679,8 +671,8 @@ async function simulateContractRead(
     .setTimeout(30)
     .build();
   const sim = await server.simulateTransaction(tx);
-  if (rpc.Api.isSimulationError(sim)) return null;
-  return (sim as rpc.Api.SimulateTransactionSuccessResponse).result?.retval ?? null;
+  if (isSimulationError(sim)) return null;
+  return getSimulationRetval(sim as rpc.Api.SimulateTransactionSuccessResponse);
 }
 
 /**
@@ -790,10 +782,7 @@ export async function getSorobanAccountBalances(
  * Ref: https://developers.stellar.org/docs/learn/encyclopedia/contract-development/types/built-in-types#address
  */
 function addressToScVal(address: string) {
-  if (StrKey.isValidEd25519PublicKey(address)) {
-    return nativeToScVal(Address.account(StrKey.decodeEd25519PublicKey(address)), { type: "address" });
-  }
-  return nativeToScVal(Address.contract(StrKey.decodeContract(address)), { type: "address" });
+  return nativeToScVal(addressFromString(address), { type: "address" });
 }
 
 /**
@@ -823,12 +812,12 @@ export async function getTokenAllowance(
     .build();
 
   const sim = await server.simulateTransaction(tx);
-  if (rpc.Api.isSimulationError(sim)) {
-    throw new Error(`Allowance simulation failed: ${sim.error}`);
+  if (isSimulationError(sim)) {
+    throw new Error(`Allowance simulation failed: ${(sim as rpc.Api.SimulateTransactionErrorResponse).error}`);
   }
-  const result = (sim as rpc.Api.SimulateTransactionSuccessResponse).result;
-  if (!result) return BigInt(0);
-  return BigInt(scValToNative(result.retval) as bigint);
+  const retval = getSimulationRetval(sim as rpc.Api.SimulateTransactionSuccessResponse);
+  if (!retval) return BigInt(0);
+  return BigInt(scValToNative(retval) as bigint);
 }
 
 /**
@@ -877,7 +866,7 @@ export async function approveToken(
 
   const prepared = await server.prepareTransaction(tx);
   const signedXDR = await defaultSigner(prepared.toXDR(), passphrase);
-  const signedTx = TransactionBuilder.fromXDR(signedXDR, passphrase);
+  const signedTx = transactionFromXDR(signedXDR, passphrase);
   const sendResult = await server.sendTransaction(signedTx);
   if (sendResult.status === "ERROR") {
     throw new Error(`Approve transaction failed: ${JSON.stringify(sendResult.errorResult)}`);
@@ -924,7 +913,7 @@ export async function deployContract(
 
   const preparedUpload = await server.prepareTransaction(uploadTx);
   const signedUploadXDR = await defaultSigner(preparedUpload.toXDR(), passphrase);
-  const uploadResult = await server.sendTransaction(TransactionBuilder.fromXDR(signedUploadXDR, passphrase));
+  const uploadResult = await server.sendTransaction(transactionFromXDR(signedUploadXDR, passphrase));
   if (uploadResult.status === "ERROR") throw new Error(`WASM upload failed: ${JSON.stringify(uploadResult.errorResult)}`);
   const uploadPolled = await server.pollTransaction(uploadResult.hash, { attempts: 30, sleepStrategy: rpc.BasicSleepStrategy });
   if (uploadPolled.status !== "SUCCESS") throw new Error(`WASM upload did not succeed: ${uploadPolled.status}`);
@@ -956,7 +945,7 @@ export async function deployContract(
 
   const preparedDeploy = await server.prepareTransaction(deployTx);
   const signedDeployXDR = await defaultSigner(preparedDeploy.toXDR(), passphrase);
-  const deployResult = await server.sendTransaction(TransactionBuilder.fromXDR(signedDeployXDR, passphrase));
+  const deployResult = await server.sendTransaction(transactionFromXDR(signedDeployXDR, passphrase));
   if (deployResult.status === "ERROR") throw new Error(`Contract deploy failed: ${JSON.stringify(deployResult.errorResult)}`);
   const deployPolled = await server.pollTransaction(deployResult.hash, { attempts: 30, sleepStrategy: rpc.BasicSleepStrategy });
   if (deployPolled.status !== "SUCCESS") throw new Error(`Contract deploy did not succeed: ${deployPolled.status}`);
@@ -987,7 +976,7 @@ export async function upgradeContract(
 
   const prepared = await server.prepareTransaction(tx);
   const signedXDR = await defaultSigner(prepared.toXDR(), passphrase);
-  const result = await server.sendTransaction(TransactionBuilder.fromXDR(signedXDR, passphrase));
+  const result = await server.sendTransaction(transactionFromXDR(signedXDR, passphrase));
   if (result.status === "ERROR") throw new Error(`Upgrade failed: ${JSON.stringify(result.errorResult)}`);
   const polled = await server.pollTransaction(result.hash, { attempts: 30, sleepStrategy: rpc.BasicSleepStrategy });
   if (polled.status !== "SUCCESS") throw new Error(`Upgrade did not succeed: ${polled.status}`);

--- a/src/lib/wallet-adapters.ts
+++ b/src/lib/wallet-adapters.ts
@@ -24,13 +24,7 @@
  * rather than SEP-0007 URIs.
  */
 
-import { Networks } from "@stellar/stellar-sdk";
-import {
-  isConnected as freighterIsConnected,
-  getAddress as freighterGetAddress,
-  getNetwork as freighterGetNetwork,
-  signTransaction as freighterSignTransaction,
-} from "@stellar/freighter-api";
+import { Networks, checkFreighterConnection, getFreighterAddress, getFreighterNetwork, signWithFreighter } from "./stellar-sdk";
 
 // ─── Shared types ────────────────────────────────────────────────────────────
 
@@ -69,37 +63,25 @@ export const freighterAdapter: WalletAdapter = {
 
   async connect() {
     try {
-      const conn = await freighterIsConnected();
+      const conn = await checkFreighterConnection();
       if (!conn.isConnected) return null;
-      const { address } = await freighterGetAddress();
-      return address || null;
+      return await getFreighterAddress();
     } catch {
       return null;
     }
   },
 
   async getAddress() {
-    try {
-      const { address } = await freighterGetAddress();
-      return address || null;
-    } catch {
-      return null;
-    }
+    return getFreighterAddress();
   },
 
   async getNetwork() {
-    try {
-      const result = await freighterGetNetwork();
-      return result.network === Networks.PUBLIC ? "PUBLIC" : "TESTNET";
-    } catch {
-      return "TESTNET";
-    }
+    return getFreighterNetwork();
   },
 
   async signTransaction(xdr, networkPassphrase) {
-    const result = await freighterSignTransaction(xdr, { networkPassphrase });
-    if ("error" in result && result.error) throw new Error(`Freighter: ${result.error}`);
-    return (result as { signedTxXdr: string }).signedTxXdr;
+    const result = await signWithFreighter(xdr, networkPassphrase);
+    return result.signedTxXdr;
   },
 };
 

--- a/src/services/soroban.ts
+++ b/src/services/soroban.ts
@@ -1,5 +1,5 @@
-import { rpc } from "@stellar/stellar-sdk";
-import type { Transaction, FeeBumpTransaction } from "@stellar/stellar-sdk";
+import { rpc, isSimulationError, getSimulationMinFee } from "@/lib/stellar-sdk";
+import type { Transaction, FeeBumpTransaction } from "@/lib/stellar-sdk";
 import { getSorobanRpcServer } from "@/lib/stellar";
 
 export interface SimulationResult {
@@ -22,12 +22,12 @@ export async function simulateSorobanTransaction(
     const server = getSorobanRpcServer(network);
     const sim = await server.simulateTransaction(tx);
 
-    if (rpc.Api.isSimulationError(sim)) {
+    if (isSimulationError(sim)) {
       return { minFee: null, error: parseSimError((sim as rpc.Api.SimulateTransactionErrorResponse).error ?? "") };
     }
 
-    const minFee = (sim as rpc.Api.SimulateTransactionSuccessResponse).minResourceFee ?? null;
-    return { minFee: minFee != null ? String(minFee) : null, error: null };
+    const minFee = getSimulationMinFee(sim as rpc.Api.SimulateTransactionSuccessResponse);
+    return { minFee, error: null };
   } catch (e) {
     console.warn("Soroban pre-flight unavailable, falling back to manual fee:", e);
     return { minFee: null, error: null };


### PR DESCRIPTION
closes #93

- Pin @stellar/stellar-sdk to 15.1.0 and @stellar/freighter-api to 6.0.1
- Add src/lib/stellar-sdk.ts abstraction layer over all SDK imports
- Route stellar.ts, wallet-adapters.ts, horizon-stream.ts, soroban.ts through the abstraction layer
- Add integration test suite (stellar-sdk-integration.test.ts) as SDK regression guard
- Add Dependabot config to flag SDK version updates weekly
- Document SDK upgrade checklist in CONTRIBUTING.md