### PR TITLE
fix(components): resolve Rules of Hooks violation in FeatureFlagPanel

### DIFF
--- a/src/components/FeatureFlagPanel.tsx
+++ b/src/components/FeatureFlagPanel.tsx
@@ -8,11 +8,12 @@ import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
  * Only renders when NODE_ENV is 'development'.
  */
 export function FeatureFlagPanel() {
-  if (process.env.NODE_ENV !== 'development') return null;
-
-  const { flags, devOverrides, isEnabled, setOverride, clearOverride } = useFeatureFlags();
+   const { flags, devOverrides, isEnabled, setOverride, clearOverride } = useFeatureFlags();
   const [isOpen, setIsOpen] = useState(false);
 
+  if (process.env.NODE_ENV !== 'development') return null;
+
+ 
   return (
     <>
       {/* Toggle button — fixed bottom-right */}


### PR DESCRIPTION
Closes #216

### Problem
`FeatureFlagPanel` called `useFeatureFlags()` and `useState()` after a conditional early return (`if (process.env.NODE_ENV !== 'development') return null;`), violating React's Rules of Hooks.

### Change
Moved both hook calls to the top of the component function body, directly above the conditional return. The component still renders `null` outside of development; behaviour is unchanged in both dev and prod.

### Files modified
- `src/components/FeatureFlagPanel.tsx`

### Definition of Done
- [x] Both hooks are called before any conditional return
- [x] Component behaviour in dev and prod is unchanged
- [x] `eslint-plugin-react-hooks` rules-of-hooks rule passes on this file