### PR TITLE
fix(wallet): fix useWallet guard when used outside WalletProvider (#215)

### DIFF
--- a/src/__tests__/walletProvider.test.ts
+++ b/src/__tests__/walletProvider.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { useWallet } from "../components/wallet-provider";
+
+describe("useWallet", () => {
+  it("throws an error when called outside of WalletProvider", () => {
+    expect(() => {
+      useWallet();
+    }).toThrow("useWallet must be used within a WalletProvider");
+  });
+});

--- a/src/components/wallet-provider.tsx
+++ b/src/components/wallet-provider.tsx
@@ -13,15 +13,7 @@ interface WalletContextType {
   disconnect: () => void;
 }
 
-const WalletContext = createContext<WalletContextType>({
-  address: null,
-  publicKey: null,
-  network: "TESTNET",
-  isConnected: false,
-  isConnecting: false,
-  connect: async () => {},
-  disconnect: () => {},
-});
+const WalletContext = createContext<WalletContextType | null>(null);
 
 export function WalletProvider({ children }: { children: ReactNode }) {
   const [address, setAddress] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
Fixes #215.

Sets `WalletContext` default to `null` so `useWallet()` properly throws `"useWallet must be used within a WalletProvider"` when called outside a provider wrapper, with tests added to `src/__tests__/walletProvider.test.ts`.
