### PR TITLE
fix(onramp): derive fee and estimated receive from shared provider fee rate (#213)

### DIFF
--- a/src/__tests__/onramp-page.test.tsx
+++ b/src/__tests__/onramp-page.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { calculateOnrampFeeAndReceive, getProviderFeeRate } from "../components/routes/onramp-page";
+
+describe("Onramp fee and estimate calculations", () => {
+  it("returns correct fee rate for moonpay and transak", () => {
+    expect(getProviderFeeRate("moonpay")).toBe(0.045);
+    expect(getProviderFeeRate("transak")).toBe(0.05);
+  });
+
+  it("calculates fee and estimated receive correctly for Moonpay ($100)", () => {
+    const { feeRate, fee, receive } = calculateOnrampFeeAndReceive(100, "moonpay");
+    expect(feeRate).toBe(0.045);
+    expect(fee).toBe(4.5);
+    expect(receive).toBe(95.5);
+    expect(fee.toFixed(2)).toBe("4.50");
+    expect(receive.toFixed(2)).toBe("95.50");
+  });
+
+  it("calculates fee and estimated receive correctly for Transak ($100)", () => {
+    const { feeRate, fee, receive } = calculateOnrampFeeAndReceive(100, "transak");
+    expect(feeRate).toBe(0.05);
+    expect(fee).toBe(5.0);
+    expect(receive).toBe(95.0);
+    expect(fee.toFixed(2)).toBe("5.00");
+    expect(receive.toFixed(2)).toBe("95.00");
+  });
+});

--- a/src/components/routes/onramp-page.tsx
+++ b/src/components/routes/onramp-page.tsx
@@ -32,6 +32,17 @@ const providers = [
   },
 ];
 
+export function getProviderFeeRate(providerId: string): number {
+  return providerId === "moonpay" ? 0.045 : 0.05;
+}
+
+export function calculateOnrampFeeAndReceive(amount: number, providerId: string) {
+  const feeRate = getProviderFeeRate(providerId);
+  const fee = amount * feeRate;
+  const receive = amount - fee;
+  return { feeRate, fee, receive };
+}
+
 export default function OnrampPage() {
   const [cAddress, setCAddress] = useState("");
   const [fiatAmount, setFiatAmount] = useState("");
@@ -42,6 +53,11 @@ export default function OnrampPage() {
   const validAddress = !cAddress || (isValidStellarAddress(cAddress) && isCAddress(cAddress));
   const validAmount = !fiatAmount || /^\d+(\.\d{1,2})?$/.test(fiatAmount);
   const canProceed = cAddress && fiatAmount && validAddress && validAmount;
+
+  const { fee: feeAmount, receive: receiveAmount } = calculateOnrampFeeAndReceive(
+    Number(fiatAmount) || 0,
+    selectedProvider
+  );
 
   const handleProviderRedirect = () => {
     if (!canProceed) return;
@@ -161,14 +177,14 @@ export default function OnrampPage() {
                   <div className="flex justify-between text-sm mt-1">
                     <span className="text-[var(--text-muted)]">Fee ({provider?.fee})</span>
                     <span>
-                      -${fiatAmount ? (Number(fiatAmount) * (selectedProvider === "moonpay" ? 0.045 : 0.05)).toFixed(2) : "0"}
+                      -${fiatAmount ? feeAmount.toFixed(2) : "0"}
                     </span>
                   </div>
                   <div className="flex justify-between text-sm mt-1">
                     <span className="text-[var(--text-muted)]">Est. receive</span>
                     <span className="font-semibold">
                       {fiatAmount && validAmount
-                        ? `~${(Number(fiatAmount) * 0.95 * (selectedProvider === "moonpay" ? 1 : 0.95)).toFixed(2)} USDC`
+                        ? `~${receiveAmount.toFixed(2)} USDC`
                         : "—"}
                     </span>
                   </div>


### PR DESCRIPTION
## Summary
Fixes #213.

Replaced separate hardcoded fee multipliers in `src/components/routes/onramp-page.tsx` with a shared helper function `calculateOnrampFeeAndReceive`, ensuring the displayed fee and estimated receive numbers derive from the same provider rate (Moonpay 4.5%, Transak 5%).
