### PR TITLE
fix(dashboard): dedupe stale in-flight balance/tx fetches on rapid network switches

### DIFF
--- a/src/components/routes/dashboard-page.tsx
+++ b/src/components/routes/dashboard-page.tsx
@@ -18,6 +18,10 @@ export default function DashboardPage() {
 
   useEffect(() => {
     if (!isConnected || !address) return;
+    // Ignore results from any fetch that was in flight when this effect
+    // re-ran (e.g. a rapid network switch). Without this, a slow response
+    // for the previous network could overwrite fresh data for the current one.
+    let cancelled = false;
     const fetchData = async () => {
       setLoading(true);
       setError(null);
@@ -26,17 +30,22 @@ export default function DashboardPage() {
           getAccountBalances(address, network),
           fetchRecentTransactions(address, network, 10),
         ]);
+        if (cancelled) return;
         setBalance(balResult.total);
         setTransactions(txResult);
       } catch (e: unknown) {
+        if (cancelled) return;
         setError(e instanceof Error ? e.message : "Failed to fetch data");
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
     fetchData();
     const interval = setInterval(fetchData, 30000);
-    return () => clearInterval(interval);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, [isConnected, address, network]);
 
   const confirmedCount = transactions.filter((t) => t.status === "confirmed").length;


### PR DESCRIPTION
## Summary
Closes #231.

`dashboard-page.tsx`'s `fetchData` effect re-runs on every `network` change, firing a fresh `Promise.all([getAccountBalances, fetchRecentTransactions])`. On a rapid double network switch, two fetches can be in flight at once and whichever resolves **last** wins — so a slow response for the previous network can overwrite fresh data for the current one, briefly showing balances/transactions for the wrong network.

## Fix
Adopt the abort/ignore pattern from the issue: a per-effect `cancelled` flag is set in the effect's cleanup, and every state update (`setBalance`/`setTransactions`/`setError`/`setLoading`) bails out once it's set. Only the latest effect's results are ever applied.

## Definition of done
- [x] Rapid network switching never displays stale-network data — results from a superseded effect are ignored.
- [x] Existing 30s polling for a stable network is unchanged (interval still fires; only cleanup semantics added).

## Verification
- `npm run typecheck` — passes
- `npm run lint` — clean
- `npm test` — 58/58 pass