### PR TITLE
a11y(contrast): audit & harden --text-muted for WCAG AA on every surface

### DIFF
--- a/src/__tests__/contrast.test.ts
+++ b/src/__tests__/contrast.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+/**
+ * Automated WCAG 2.x contrast audit for the --text-muted design token.
+ *
+ * --text-muted is used pervasively for meaningful secondary content (balances,
+ * transaction statuses, form hints), so it must clear WCAG AA (4.5:1 for normal
+ * text) against every surface it renders over — including the translucent tint
+ * overlays (e.g. bg-[var(--error)]/10) that blend into lighter backgrounds.
+ *
+ * This test parses the real token values from globals.css, so lowering the
+ * token's contrast below AA — or darkening a surface under it — fails CI.
+ */
+
+const AA_NORMAL = 4.5;
+
+const cssPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../app/globals.css",
+);
+const css = readFileSync(cssPath, "utf8");
+
+function token(name: string): string {
+  const match = css.match(new RegExp(`--${name}:\\s*(#[0-9a-fA-F]{6})`));
+  if (!match) throw new Error(`token --${name} not found in globals.css`);
+  return match[1];
+}
+
+type RGB = { r: number; g: number; b: number };
+
+function hexToRgb(hex: string): RGB {
+  const n = hex.replace("#", "");
+  return {
+    r: parseInt(n.slice(0, 2), 16),
+    g: parseInt(n.slice(2, 4), 16),
+    b: parseInt(n.slice(4, 6), 16),
+  };
+}
+
+function relativeLuminance({ r, g, b }: RGB): number {
+  const channel = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrastRatio(a: RGB, b: RGB): number {
+  const l1 = relativeLuminance(a);
+  const l2 = relativeLuminance(b);
+  const [hi, lo] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Alpha-composite `fg` at `alpha` over opaque `bg` (CSS "source-over").
+function composite(fg: RGB, alpha: number, bg: RGB): RGB {
+  return {
+    r: fg.r * alpha + bg.r * (1 - alpha),
+    g: fg.g * alpha + bg.g * (1 - alpha),
+    b: fg.b * alpha + bg.b * (1 - alpha),
+  };
+}
+
+const muted = hexToRgb(token("text-muted"));
+const background = hexToRgb(token("background"));
+const surface = hexToRgb(token("surface"));
+const surface2 = hexToRgb(token("surface-2"));
+
+// Solid surfaces --text-muted renders directly over.
+const solidSurfaces: Record<string, RGB> = {
+  "--background": background,
+  "--surface": surface,
+  "--surface-2": surface2,
+};
+
+// Translucent tint overlays that wrap muted text, blended over their base
+// surface (matches the `bg-[var(--x)]/NN` usages in the components).
+const tintOverlays: { label: string; bg: RGB }[] = (
+  [
+    ["primary", 0.05, surface],
+    ["primary", 0.1, surface],
+    ["secondary", 0.1, surface],
+    ["accent", 0.1, surface],
+    ["success", 0.1, surface],
+    ["error", 0.1, surface],
+  ] as const
+).map(([name, alpha, base]) => ({
+  label: `${name}/${alpha * 100}% on surface`,
+  bg: composite(hexToRgb(token(name)), alpha, base),
+}));
+
+describe("--text-muted WCAG AA contrast", () => {
+  it.each(Object.entries(solidSurfaces))(
+    "meets AA over %s",
+    (_label, bg) => {
+      expect(contrastRatio(muted, bg)).toBeGreaterThanOrEqual(AA_NORMAL);
+    },
+  );
+
+  it.each(tintOverlays)("meets AA over $label", ({ bg }) => {
+    expect(contrastRatio(muted, bg)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,11 @@
   --surface: #141519;
   --surface-2: #1e1f25;
   --border: #2a2b32;
-  --text-muted: #8a8c93;
+  /* WCAG AA audit (see src/__tests__/contrast.test.ts): the previous #8a8c93
+     cleared 4.5:1 only by a hair over tinted overlays (secondary/10% = 4.61:1).
+     #a0a2aa keeps the same gray-blue hue with a comfortable margin (>=6:1 on
+     every surface it is used over). */
+  --text-muted: #a0a2aa;
   --success: #00b894;
   --warning: #fdcb6e;
   --error: #e17055;


### PR DESCRIPTION
## Summary
Closes #225.

Audited the `--text-muted` token's contrast against **every** background it renders over — the three solid surfaces plus the translucent tint overlays (`bg-[var(--x)]/10`) that blend into lighter colors — using the WCAG 2.x relative-luminance formula (the same algorithm axe DevTools / WebAIM use).

## Audit results

Muted text is almost all `text-xs` (12px) → **normal text**, so it needs the full **4.5:1**, not the 3:1 large-text threshold.

| Background | `#8a8c93` (before) | `#a0a2aa` (after) |
|---|---|---|
| `--background` #0a0b0e | 5.86:1 ✅ | 7.72:1 ✅ |
| `--surface` #141519 | 5.43:1 ✅ | 7.16:1 ✅ |
| `--surface-2` #1e1f25 | 4.89:1 ⚠️ | 6.45:1 ✅ |
| `primary`/5% on surface | 5.21:1 ✅ | 6.87:1 ✅ |
| `primary`/10% on surface | 4.97:1 ⚠️ | 6.56:1 ✅ |
| `secondary`/10% on surface | **4.61:1** ⚠️ | 6.08:1 ✅ |
| `accent`/10% on surface | 4.70:1 ⚠️ | 6.20:1 ✅ |
| `success`/10% on surface | 4.73:1 ⚠️ | 6.24:1 ✅ |
| `error`/10% on surface | 4.81:1 ⚠️ | 6.35:1 ✅ |

**Finding:** the previous `#8a8c93` technically cleared AA everywhere, but only by a hair — as low as **4.61:1** over the `secondary/10%` overlay and 4.89:1 over `--surface-2`. That's a fragile pass for 12px text (sub-pixel antialiasing effectively lowers rendered contrast, and any future surface tweak could tip it below the line).

## Fix
- Raised `--text-muted` from `#8a8c93` → `#a0a2aa` (same gray-blue hue, lighter). It now clears **≥6:1** on every surface it's used over, and reaches AAA (7:1) on the base background/surface — while still reading as clearly muted secondary text.
- Added `src/__tests__/contrast.test.ts`, which **parses the real token values from `globals.css`** and asserts AA (4.5:1) over each solid surface and tint overlay. Any future regression (lowering the token's contrast, or darkening a surface under it) now fails CI.

## Definition of done
- [x] Contrast ratio for `--text-muted` on every surface it's used over is documented (table above + inline CSS comment + test).
- [x] Any thin/failing combination is adjusted to comfortably meet WCAG AA.
- [x] Verified with an automated contrast-checking tool — the WCAG 2.x algorithm (axe/WebAIM-equivalent), committed as a reproducible vitest suite.

## Verification
- `npm run typecheck` — passes
- `npm run lint` — clean
- `npm test` — 67/67 pass (9 new contrast assertions)