### PR TITLE
fix(validation): StrKey-based address validation + real checksum/alphabet edge-case tests

### DIFF
--- a/src/__tests__/stellar.test.ts
+++ b/src/__tests__/stellar.test.ts
@@ -1,15 +1,35 @@
 import { describe, it, expect } from "vitest";
+import { Keypair, StrKey } from "@stellar/stellar-sdk";
 import { isValidStellarAddress, isCAddress, isGAddress } from "@/lib/stellar";
 
-const G_ADDRESS = "GAIUIQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5A";
-const C_ADDRESS = "CAIUIQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5A";
+// Real, checksum-valid StrKeys derived from the SDK — not hardcoded strings
+// that merely "look" the right length/prefix. The G-address is a genuine
+// Ed25519 public key; the C-address is a genuine contract StrKey encoded from
+// the same 32-byte body. Both carry a valid base32 alphabet and CRC16 checksum.
+const keypair = Keypair.random();
+const G_ADDRESS = keypair.publicKey();
+const C_ADDRESS = StrKey.encodeContract(keypair.rawPublicKey());
+
+describe("fixtures are genuinely valid StrKeys", () => {
+  it("G_ADDRESS is a valid Ed25519 public key", () => {
+    expect(StrKey.isValidEd25519PublicKey(G_ADDRESS)).toBe(true);
+    expect(G_ADDRESS).toMatch(/^G/);
+    expect(G_ADDRESS).toHaveLength(56);
+  });
+
+  it("C_ADDRESS is a valid contract StrKey", () => {
+    expect(StrKey.isValidContract(C_ADDRESS)).toBe(true);
+    expect(C_ADDRESS).toMatch(/^C/);
+    expect(C_ADDRESS).toHaveLength(56);
+  });
+});
 
 describe("isValidStellarAddress", () => {
-  it("accepts valid G-address", () => {
+  it("accepts a real, checksum-valid G-address", () => {
     expect(isValidStellarAddress(G_ADDRESS)).toBe(true);
   });
 
-  it("accepts valid C-address", () => {
+  it("accepts a real, checksum-valid C-address", () => {
     expect(isValidStellarAddress(C_ADDRESS)).toBe(true);
   });
 
@@ -25,28 +45,68 @@ describe("isValidStellarAddress", () => {
     const addr = "X" + G_ADDRESS.slice(1);
     expect(isValidStellarAddress(addr)).toBe(false);
   });
+
+  // Regression: the old /^[G|C].../ character class treated '|' as an allowed
+  // first character, so a pipe-prefixed 56-char string wrongly validated.
+  it("rejects a pipe-prefixed 56-character string", () => {
+    const piped = "|" + G_ADDRESS.slice(1);
+    expect(piped).toHaveLength(56);
+    expect(isValidStellarAddress(piped)).toBe(false);
+  });
+
+  // Regression: the old [A-Z0-9] body class accepted 0/1/8/9, which are NOT in
+  // the Stellar base32 alphabet (RFC 4648 uses A-Z and 2-7).
+  it.each(["0", "1", "8", "9"])(
+    "rejects an address containing invalid base32 char '%s' in the body",
+    (badChar) => {
+      const corrupted = G_ADDRESS.slice(0, 10) + badChar + G_ADDRESS.slice(11);
+      expect(corrupted).toHaveLength(56);
+      expect(isValidStellarAddress(corrupted)).toBe(false);
+    },
+  );
+
+  // Regression: the old regex performed no checksum verification at all, so a
+  // single-character corruption that stays within the alphabet slipped through.
+  it("rejects a checksum-corrupted address (last character flipped)", () => {
+    const last = G_ADDRESS.slice(-1);
+    const flipped = last === "A" ? "B" : "A";
+    const corrupted = G_ADDRESS.slice(0, -1) + flipped;
+    expect(corrupted).toHaveLength(56);
+    expect(corrupted).not.toBe(G_ADDRESS);
+    expect(isValidStellarAddress(corrupted)).toBe(false);
+  });
 });
 
 describe("isCAddress", () => {
-  it("detects C-address", () => {
+  it("detects a valid C-address", () => {
     expect(isCAddress(C_ADDRESS)).toBe(true);
   });
 
-  it("rejects G-address", () => {
+  it("rejects a G-address", () => {
     expect(isCAddress(G_ADDRESS)).toBe(false);
   });
 
-  it("rejects short address", () => {
+  it("rejects a short address", () => {
     expect(isCAddress("CABC")).toBe(false);
+  });
+
+  it("rejects a C-prefixed string that fails the checksum", () => {
+    const corrupted = C_ADDRESS.slice(0, -1) + (C_ADDRESS.slice(-1) === "A" ? "B" : "A");
+    expect(isCAddress(corrupted)).toBe(false);
   });
 });
 
 describe("isGAddress", () => {
-  it("detects G-address", () => {
+  it("detects a valid G-address", () => {
     expect(isGAddress(G_ADDRESS)).toBe(true);
   });
 
-  it("rejects C-address", () => {
+  it("rejects a C-address", () => {
     expect(isGAddress(C_ADDRESS)).toBe(false);
+  });
+
+  it("rejects a G-prefixed string that fails the checksum", () => {
+    const corrupted = G_ADDRESS.slice(0, -1) + (G_ADDRESS.slice(-1) === "A" ? "B" : "A");
+    expect(isGAddress(corrupted)).toBe(false);
   });
 });

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -13,6 +13,7 @@ import {
   Horizon,
   rpc,
   Account,
+  StrKey,
 } from "@stellar/stellar-sdk";
 import { BRIDGE_CONTRACT_ID } from "./types";
 import { withSequenceRetry } from "./sequenceManager";
@@ -84,16 +85,20 @@ export async function getCurrentNetwork(): Promise<"PUBLIC" | "TESTNET"> {
   }
 }
 
+// Validate against the SDK's StrKey, which enforces the correct base32
+// alphabet (A-Z, 2-7 — no 0/1/8/9) and the trailing CRC16 checksum. A
+// hand-rolled regex cannot verify the checksum and, as [G|C] showed, is easy
+// to get subtly wrong (that character class also accepted a leading '|').
 export function isValidStellarAddress(address: string): boolean {
-  return /^[G|C][A-Z0-9]{55}$/.test(address);
+  return StrKey.isValidEd25519PublicKey(address) || StrKey.isValidContract(address);
 }
 
 export function isCAddress(address: string): boolean {
-  return address.startsWith("C") && address.length === 56;
+  return StrKey.isValidContract(address);
 }
 
 export function isGAddress(address: string): boolean {
-  return address.startsWith("G") && address.length === 56;
+  return StrKey.isValidEd25519PublicKey(address);
 }
 
 export interface PaymentResult {


### PR DESCRIPTION
## Summary
Closes #212, and the two paired bugs it depends on: #210 and #211.

The three issues are inseparable: #212's Definition of Done requires the new tests to *pass against a StrKey-based implementation*, which doesn't exist until #210/#211 are fixed. Doing them together yields one green, self-contained PR.

## The bugs (#210, #211)
Address validation used a hand-rolled regex:
```
/^[G|C][A-Z0-9]{55}$/
```
- **#210 (pipe):** `[G|C]` is a character *class* — it allows `G`, `C`, **and the literal `|`**. A string like `|AAA…` (56 chars) passed validation.
- **#211 (alphabet + checksum):** `[A-Z0-9]` accepts `0/1/8/9`, which are **not** in the Stellar base32 alphabet (RFC 4648 uses `A–Z` and `2–7`). The regex also verified **no checksum**, so an alphabet-valid but corrupted key passed. `isCAddress`/`isGAddress` only checked prefix + length.

## The fix
Validate through the SDK's `StrKey`, which enforces the correct alphabet **and** the trailing CRC16 checksum:
```ts
isValidStellarAddress → StrKey.isValidEd25519PublicKey(a) || StrKey.isValidContract(a)
isCAddress            → StrKey.isValidContract(a)
isGAddress            → StrKey.isValidEd25519PublicKey(a)
```
(`StrKey` is added to the file's existing static SDK import, so no new bundle cost.)

## The tests (#212)
Rewrote `src/__tests__/stellar.test.ts` so **no hand-typed "looks-valid" fixtures remain**:
- Fixtures are derived from the SDK — `Keypair.random().publicKey()` (G) and `StrKey.encodeContract(...)` (C) — and asserted genuinely valid.
- **Pipe:** a `|`-prefixed 56-char string is rejected.
- **Alphabet:** a body char of `0`, `1`, `8`, or `9` is rejected (parameterized).
- **Checksum:** a last-character-flipped copy of a valid G/C address is rejected.

## Verified the DoD directly
Temporarily restoring the old regex, the 8 new regression cases **fail**; with the StrKey implementation they **pass**:
```
Against old regex:  Tests  8 failed | 12 passed (20)
Against StrKey:     Tests  20 passed (20)
```

## Definition of done
- [x] Tests fail against the pre-fix implementation and pass against the StrKey-based one.
- [x] No hardcoded "looks valid" fixture strings remain untested against real validation rules.

## Verification
- `npm run typecheck` — passes
- `npm run lint` — no new problems (the 2 pre-existing errors are in `FeatureFlagPanel.tsx`, untouched here)
- `npm test` — 68/68 pass