### PR TITLE
Audit and fix keyboard navigation in mobile nav menu

### DIFF
--- a/src/__tests__/navbar-a11y.test.tsx
+++ b/src/__tests__/navbar-a11y.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createRoot, Root } from "react-dom/client";
+import Navbar from "@/components/navbar";
+
+// Set React act environment flag for jsdom test runner
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/bridge",
+  useRouter: () => ({
+    push: vi.fn(),
+    prefetch: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock wallet provider
+vi.mock("@/components/wallet-provider", () => ({
+  useWallet: () => ({
+    isConnected: false,
+    address: null,
+    connect: vi.fn(),
+    isConnecting: false,
+  }),
+}));
+
+describe("Navbar Mobile Menu A11Y & Focus Management", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    container = null;
+    root = null;
+    vi.restoreAllMocks();
+  });
+
+  it("sets correct ARIA attributes on toggle button and mobile menu", async () => {
+    await act(async () => {
+      root?.render(<Navbar />);
+    });
+
+    const toggleBtn = container?.querySelector('button[aria-controls="mobile-menu"]') as HTMLButtonElement;
+    expect(toggleBtn).not.toBeNull();
+    expect(toggleBtn.getAttribute("aria-expanded")).toBe("false");
+    expect(toggleBtn.getAttribute("aria-label")).toBe("Open menu");
+
+    // Click toggle to open menu
+    await act(async () => {
+      toggleBtn.click();
+    });
+
+    expect(toggleBtn.getAttribute("aria-expanded")).toBe("true");
+    expect(toggleBtn.getAttribute("aria-label")).toBe("Close menu");
+
+    const mobileMenu = container?.querySelector("#mobile-menu");
+    expect(mobileMenu).not.toBeNull();
+    expect(mobileMenu?.getAttribute("role")).toBe("region");
+    expect(mobileMenu?.getAttribute("aria-label")).toBe("Mobile Navigation");
+  });
+
+  it("moves focus to the first nav link when mobile menu opens", async () => {
+    vi.useFakeTimers();
+
+    await act(async () => {
+      root?.render(<Navbar />);
+    });
+
+    const toggleBtn = container?.querySelector('button[aria-controls="mobile-menu"]') as HTMLButtonElement;
+
+    await act(async () => {
+      toggleBtn.click();
+    });
+
+    // Run animation frames / microtasks
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    const firstLink = container?.querySelector('#mobile-menu a[href="/bridge"]') as HTMLAnchorElement;
+    expect(document.activeElement).toBe(firstLink);
+
+    vi.useRealTimers();
+  });
+
+  it("closes mobile menu and restores focus to toggle button when Escape key is pressed", async () => {
+    vi.useFakeTimers();
+
+    await act(async () => {
+      root?.render(<Navbar />);
+    });
+
+    const toggleBtn = container?.querySelector('button[aria-controls="mobile-menu"]') as HTMLButtonElement;
+
+    // Open menu
+    await act(async () => {
+      toggleBtn.click();
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(container?.querySelector("#mobile-menu")).not.toBeNull();
+
+    // Press Escape
+    await act(async () => {
+      const escapeEvent = new KeyboardEvent("keydown", { key: "Escape", bubbles: true });
+      window.dispatchEvent(escapeEvent);
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(container?.querySelector("#mobile-menu")).toBeNull();
+    expect(document.activeElement).toBe(toggleBtn);
+
+    vi.useRealTimers();
+  });
+
+  it("restores focus to toggle button when mobile menu is closed via toggle button click", async () => {
+    vi.useFakeTimers();
+
+    await act(async () => {
+      root?.render(<Navbar />);
+    });
+
+    const toggleBtn = container?.querySelector('button[aria-controls="mobile-menu"]') as HTMLButtonElement;
+
+    // Open menu
+    await act(async () => {
+      toggleBtn.click();
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    // Close menu by clicking toggle button again
+    await act(async () => {
+      toggleBtn.click();
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(container?.querySelector("#mobile-menu")).toBeNull();
+    expect(document.activeElement).toBe(toggleBtn);
+
+    vi.useRealTimers();
+  });
+});

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import React, { memo, useState, useCallback, useMemo } from "react";
+/**
+ * Keyboard Navigation & Accessibility (A11Y) Behavior for Mobile Menu:
+ * - When mobile menu opens (mobileOpen = true), focus programmatically moves to the first interactive nav link inside the menu.
+ * - Pressing 'Escape' key while menu is open closes the mobile menu.
+ * - When mobile menu closes, focus is programmatically restored to the toggle button.
+ * - Toggle button features proper ARIA attributes (`aria-expanded`, `aria-controls`, `aria-label`).
+ * - Mobile menu container includes `id="mobile-menu"`, `role="region"`, and `aria-label="Mobile Navigation"`.
+ */
+
+import React, { memo, useState, useCallback, useMemo, useRef, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Wallet, ArrowLeftRight, CreditCard, Building2, LayoutDashboard, Menu, X } from "lucide-react";
@@ -19,6 +28,10 @@ const Navbar = () => {
   const { isConnected, address, connect, isConnecting } = useWallet();
   const [mobileOpen, setMobileOpen] = useState(false);
 
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
+  const wasOpenRef = useRef(false);
+
   const toggleMobile = useCallback(() => setMobileOpen((v) => !v), []);
   const closeMobile = useCallback(() => setMobileOpen(false), []);
   const handleConnect = useCallback(() => connect(), [connect]);
@@ -26,6 +39,37 @@ const Navbar = () => {
     connect();
     setMobileOpen(false);
   }, [connect]);
+
+  // Keyboard navigation: Handle Escape key to close mobile menu
+  useEffect(() => {
+    if (!mobileOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMobileOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [mobileOpen]);
+
+  // Focus management: Move focus into menu on open, return focus to toggle on close
+  useEffect(() => {
+    if (mobileOpen) {
+      const timer = requestAnimationFrame(() => {
+        const firstFocusable = mobileMenuRef.current?.querySelector<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        firstFocusable?.focus();
+      });
+      wasOpenRef.current = true;
+      return () => cancelAnimationFrame(timer);
+    } else if (wasOpenRef.current) {
+      toggleButtonRef.current?.focus();
+      wasOpenRef.current = false;
+    }
+  }, [mobileOpen]);
 
   const addressDisplay = useMemo(() => (address ? `${address.slice(0, 4)}...${address.slice(-4)}` : null), [address]);
 
@@ -78,7 +122,14 @@ const Navbar = () => {
               </button>
             )}
 
-            <button onClick={toggleMobile} className="md:hidden p-2 rounded-lg text-[var(--text-muted)] hover:text-[var(--foreground)]">
+            <button
+              ref={toggleButtonRef}
+              onClick={toggleMobile}
+              aria-expanded={mobileOpen}
+              aria-controls="mobile-menu"
+              aria-label={mobileOpen ? "Close menu" : "Open menu"}
+              className="md:hidden p-2 rounded-lg text-[var(--text-muted)] hover:text-[var(--foreground)]"
+            >
               {mobileOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
             </button>
           </div>
@@ -86,7 +137,13 @@ const Navbar = () => {
       </div>
 
       {mobileOpen && (
-        <div className="md:hidden border-t border-[var(--border)] bg-[var(--background)]">
+        <div
+          ref={mobileMenuRef}
+          id="mobile-menu"
+          role="region"
+          aria-label="Mobile Navigation"
+          className="md:hidden border-t border-[var(--border)] bg-[var(--background)]"
+        >
           <div className="px-4 py-3 space-y-1">
             {navLinks.map((link) => {
               const Icon = link.icon;
@@ -125,3 +182,4 @@ const Navbar = () => {
 };
 
 export default memo(Navbar);
+


### PR DESCRIPTION
Closes: #223 

This pull request significantly improves the accessibility (A11Y) and keyboard navigation of the mobile menu in the `Navbar` component. It introduces focus management, proper ARIA attributes, and keyboard handling to ensure a better experience for keyboard and screen reader users. Comprehensive tests are also added to verify these behaviors.

**Accessibility & Focus Management Enhancements:**

* The mobile menu toggle button now uses `aria-expanded`, `aria-controls`, and `aria-label` attributes, and the menu container uses `id="mobile-menu"`, `role="region"`, and `aria-label="Mobile Navigation"` for improved screen reader support.
* When the mobile menu opens, focus is programmatically moved to the first navigation link; when it closes (either by Escape key or toggle button), focus returns to the toggle button. [[1]](diffhunk://#diff-22f07440d147576aefe7a062a84ac12e07bbb1bdc66c02cf368e71261439cc4bR31-R34) [[2]](diffhunk://#diff-22f07440d147576aefe7a062a84ac12e07bbb1bdc66c02cf368e71261439cc4bR43-R73)
* Pressing the Escape key while the menu is open closes the menu.

**Testing:**

* A new test file `navbar-a11y.test.tsx` is added to verify ARIA attributes, focus movement, Escape key handling, and focus restoration behaviors.

**Documentation:**

* Inline documentation is added to the top of `navbar.tsx` summarizing the new accessibility and keyboard navigation behaviors.…mobile nav menu (#223)