### PR TITLE
Respect prefers-reduced-motion for spinners and animations

### DIFF
--- a/src/__tests__/reduced-motion.test.ts
+++ b/src/__tests__/reduced-motion.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+describe("Reduced Motion Support (A11Y)", () => {
+  it("includes prefers-reduced-motion media query in globals.css", () => {
+    const globalsCssPath = path.resolve(__dirname, "../app/globals.css");
+    const cssContent = fs.readFileSync(globalsCssPath, "utf-8");
+
+    expect(cssContent).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(cssContent).toContain("animation: none !important");
+    expect(cssContent).toContain("transition-duration: 0.01ms !important");
+    expect(cssContent).toContain("transform: none !important");
+  });
+
+  it("applies motion-reduce:animate-none to loading spinner components", () => {
+    const loadingPath = path.resolve(__dirname, "../app/loading.tsx");
+    const loadingContent = fs.readFileSync(loadingPath, "utf-8");
+    expect(loadingContent).toContain("motion-reduce:animate-none");
+
+    const historyPath = path.resolve(__dirname, "../components/transaction-history.tsx");
+    const historyContent = fs.readFileSync(historyPath, "utf-8");
+    expect(historyContent).toContain("motion-reduce:animate-none");
+
+    const dashboardPath = path.resolve(__dirname, "../components/routes/dashboard-page.tsx");
+    const dashboardContent = fs.readFileSync(dashboardPath, "utf-8");
+    expect(dashboardContent).toContain("motion-reduce:animate-none");
+
+    const bridgePath = path.resolve(__dirname, "../app/bridge/page.tsx");
+    const bridgeContent = fs.readFileSync(bridgePath, "utf-8");
+    expect(bridgeContent).toContain("motion-reduce:animate-none");
+  });
+});

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -233,7 +233,7 @@ export default function BridgePage() {
                   >
                     {txStatus === "signing" || txStatus === "submitting" ? (
                       <>
-                        <Loader2 className="w-4 h-4 animate-spin" />
+                        <Loader2 className="w-4 h-4 animate-spin motion-reduce:animate-none" />
                         {txStatus === "signing" ? "Signing..." : "Submitting..."}
                       </>
                     ) : (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,3 +96,25 @@ body {
   transform: translateY(-2px);
   box-shadow: 0 8px 30px rgba(108, 92, 231, 0.12);
 }
+
+/* Reduced motion preference support (A11Y) */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .animate-spin {
+    animation: none !important;
+  }
+
+  .card-hover:hover {
+    transform: none !important;
+    box-shadow: none !important;
+  }
+}
+

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -4,7 +4,7 @@ export default function Loading() {
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
       <div className="flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-[var(--primary-light)]" />
+        <Loader2 className="w-8 h-8 animate-spin motion-reduce:animate-none text-[var(--primary-light)]" />
       </div>
     </div>
   );

--- a/src/components/routes/dashboard-page.tsx
+++ b/src/components/routes/dashboard-page.tsx
@@ -122,7 +122,7 @@ export default function DashboardPage() {
           <div className="text-xs text-[var(--text-muted)] mb-1">XLM Balance</div>
           {loading ? (
             <div className="flex items-center gap-2">
-              <Loader2 className="w-4 h-4 animate-spin text-[var(--text-muted)]" />
+              <Loader2 className="w-4 h-4 animate-spin motion-reduce:animate-none text-[var(--text-muted)]" />
               <span className="text-xs text-[var(--text-muted)]">Loading...</span>
             </div>
           ) : (
@@ -139,7 +139,7 @@ export default function DashboardPage() {
           <div className="text-xs text-[var(--text-muted)] mb-1">Transactions</div>
           {loading ? (
             <div className="flex items-center gap-2">
-              <Loader2 className="w-4 h-4 animate-spin text-[var(--text-muted)]" />
+              <Loader2 className="w-4 h-4 animate-spin motion-reduce:animate-none text-[var(--text-muted)]" />
               <span className="text-xs text-[var(--text-muted)]">Loading...</span>
             </div>
           ) : (

--- a/src/components/transaction-history.tsx
+++ b/src/components/transaction-history.tsx
@@ -79,7 +79,7 @@ function TransactionHistory({ transactions, loading, network }: Props) {
       </div>
       {loading ? (
         <div className="p-12 flex items-center justify-center">
-          <Loader2 className="w-6 h-6 animate-spin text-[var(--text-muted)]" />
+          <Loader2 className="w-6 h-6 animate-spin motion-reduce:animate-none text-[var(--text-muted)]" />
         </div>
       ) : transactions.length === 0 ? (
         <div className="p-12 text-center">


### PR DESCRIPTION
Closes: #229

This pull request adds accessibility improvements to support users who prefer reduced motion. It introduces global CSS rules that respect the `prefers-reduced-motion` media query and updates all loading spinner components to disable animations when reduced motion is enabled. Additionally, automated tests are added to verify these enhancements.

**Accessibility: Reduced Motion Support**

* [`globals.css`](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R99-R120): Adds a `@media (prefers-reduced-motion: reduce)` block to globally minimize or disable animations, transitions, and transforms for users with reduced motion preferences.
* All spinner components (`loading.tsx`, `dashboard-page.tsx`, `transaction-history.tsx`, `bridge/page.tsx`): Appends the `motion-reduce:animate-none` utility to spinner class names, ensuring spinners do not animate when reduced motion is requested. [[1]](diffhunk://#diff-6c1416caebcef91941795358fc2439c029959ddb85eb022c04e3c92cf39e9851L7-R7) [[2]](diffhunk://#diff-5c573fb3e722eaee853052642d097ea08d637a7747fb35f874b7e27da2de3855L125-R125) [[3]](diffhunk://#diff-5c573fb3e722eaee853052642d097ea08d637a7747fb35f874b7e27da2de3855L142-R142) [[4]](diffhunk://#diff-04d7465296344cba0125cdef9b285a2016aa27089b932d5a0c369875b6633cf2L82-R82) [[5]](diffhunk://#diff-7aaf4e2878b12c9516c47fc10cf2da717763bb620690e40a17e80c9ebb10c3d6L236-R236)

**Testing**

* [`reduced-motion.test.ts`](diffhunk://#diff-ed6ffdeae67f7b0ff96fd64374a49099db4f29d329cae7f6b5b221545c2cf62fR1-R34): Adds tests to verify that the reduced motion CSS and spinner class updates are present and functioning as intended.… animations (#229)