### PR TITLE
Unify Stellar SDK imports and remove redundant dynamic imports

### DIFF
--- a/src/__tests__/stellar-imports.test.ts
+++ b/src/__tests__/stellar-imports.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { getHorizonServer, getSorobanRpcServer, getNetworkPassphrase } from "@/lib/stellar";
+
+describe("Stellar SDK Imports Unification", () => {
+  it("does not contain redundant dynamic import('@stellar/stellar-sdk') calls in source", () => {
+    const stellarFilePath = path.resolve(__dirname, "../lib/stellar.ts");
+    const sourceCode = fs.readFileSync(stellarFilePath, "utf-8");
+
+    // Verify no internal functions dynamically import @stellar/stellar-sdk
+    expect(sourceCode).not.toContain('await import("@stellar/stellar-sdk")');
+    expect(sourceCode).not.toContain("await import('@stellar/stellar-sdk')");
+  });
+
+  it("returns Horizon server instance correctly", async () => {
+    const server = await getHorizonServer("TESTNET");
+    expect(server).toBeDefined();
+    expect(server.serverURL.toString()).toContain("horizon-testnet.stellar.org");
+  });
+
+  it("returns Soroban RPC server instance correctly", async () => {
+    const rpcServer = await getSorobanRpcServer("TESTNET");
+    expect(rpcServer).toBeDefined();
+    expect(rpcServer.serverURL.toString()).toContain("soroban-rpc-testnet.stellar.org");
+  });
+
+  it("returns network passphrase correctly", async () => {
+    const publicPassphrase = await getNetworkPassphrase("PUBLIC");
+    const testnetPassphrase = await getNetworkPassphrase("TESTNET");
+
+    expect(publicPassphrase).toBe("Public Global Stellar Network ; September 2015");
+    expect(testnetPassphrase).toBe("Test SDF Network ; September 2015");
+  });
+});

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -28,17 +28,14 @@ const SOROBAN_RPC_URLS = {
 };
 
 export async function getHorizonServer(network: "PUBLIC" | "TESTNET"): Promise<Horizon.Server> {
-  const { Horizon } = await import("@stellar/stellar-sdk");
   return new Horizon.Server(HORIZON_URLS[network]);
 }
 
 export async function getSorobanRpcServer(network: "PUBLIC" | "TESTNET"): Promise<rpc.Server> {
-  const { rpc } = await import("@stellar/stellar-sdk");
   return new rpc.Server(SOROBAN_RPC_URLS[network]);
 }
 
 export async function getNetworkPassphrase(network: "PUBLIC" | "TESTNET"): Promise<string> {
-  const { Networks } = await import("@stellar/stellar-sdk");
   return network === "PUBLIC" ? Networks.PUBLIC : Networks.TESTNET;
 }
 
@@ -195,8 +192,6 @@ export async function buildAndSubmitPayment(
 ): Promise<PaymentResult> {
   const server = await getHorizonServer(network);
   const passphrase = await getNetworkPassphrase(network);
-  const { TransactionBuilder, Operation, BASE_FEE, Asset } = await import("@stellar/stellar-sdk");
-  type AssetType = InstanceType<typeof Asset>;
 
   const result = await withSequenceRetry(
     sourceAddress,
@@ -270,7 +265,6 @@ export async function bridgeViaContract(
 
   const server = await getHorizonServer(network);
   const passphrase = await getNetworkPassphrase(network);
-  const { TransactionBuilder, Operation, BASE_FEE, Asset } = await import("@stellar/stellar-sdk");
 
   const result = await withSequenceRetry(
     sourceAddress,


### PR DESCRIPTION
Closes #232

---

Closes: #232

This pull request refactors the Stellar SDK import strategy to remove redundant dynamic imports and ensure all imports are unified at the module level. It also adds a comprehensive test suite to verify the import structure and the correct functioning of key utility functions.

**Refactoring: Unified Stellar SDK Imports**

* Removed all dynamic `import("@stellar/stellar-sdk")` statements from internal functions in `stellar.ts`, so imports are now handled statically at the top level for better performance and maintainability. [[1]](diffhunk://#diff-fb265538ea28303356e27ac3d003699b18e7a7d7970a5c48aa005c5346693de6L31-L41) [[2]](diffhunk://#diff-fb265538ea28303356e27ac3d003699b18e7a7d7970a5c48aa005c5346693de6L198-L199) [[3]](diffhunk://#diff-fb265538ea28303356e27ac3d003699b18e7a7d7970a5c48aa005c5346693de6L273)

**Testing: Import Structure and Utility Functions**

* Added a new test suite `stellar-imports.test.ts` to ensure there are no redundant dynamic imports and to verify that `getHorizonServer`, `getSorobanRpcServer`, and `getNetworkPassphrase` return correct values.…(#232)