### PR TITLE
fix: replaces the per-instance IntersectionObserver in PrefetchLink w…

### DIFF
--- a/src/components/prefetch-link.tsx
+++ b/src/components/prefetch-link.tsx
@@ -2,43 +2,77 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, type ComponentProps, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, type ComponentProps, type ReactNode } from "react";
 
 type PrefetchLinkProps = ComponentProps<typeof Link> & {
   children: ReactNode;
   prefetchOnVisible?: boolean;
 };
 
-export function PrefetchLink({ href, prefetchOnVisible = true, onMouseEnter, onFocus, ...props }: PrefetchLinkProps) {
-  const router = useRouter();
-  const linkRef = useRef<HTMLAnchorElement | null>(null);
+// Skip redundant router.prefetch() calls: once a destination is prefetched we
+// never ask again, no matter how many PrefetchLink instances point at it or how
+// often they enter view / are hovered. (Next already dedupes the underlying RSC
+// requests per route; this just avoids the redundant calls.)
+const prefetched = new Set<string>();
 
-  const prefetch = () => {
-    if (typeof href === "string") {
-      router.prefetch(href);
-    }
-  };
+// A single IntersectionObserver shared by every instance, instead of allocating
+// one observer per component. Each observed element maps to the prefetch
+// callback to run when it scrolls within 200px of the viewport.
+const targets = new WeakMap<Element, () => void>();
+let sharedObserver: IntersectionObserver | null = null;
 
-  useEffect(() => {
-    if (!prefetchOnVisible || typeof window === "undefined" || !linkRef.current) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
+function getSharedObserver(): IntersectionObserver | null {
+  if (typeof window === "undefined" || typeof IntersectionObserver === "undefined") {
+    return null;
+  }
+  if (!sharedObserver) {
+    sharedObserver = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            prefetch();
-            observer.disconnect();
+          if (!entry.isIntersecting) {
+            return;
           }
+          targets.get(entry.target)?.();
+          sharedObserver?.unobserve(entry.target);
+          targets.delete(entry.target);
         });
       },
       { rootMargin: "200px" }
     );
+  }
+  return sharedObserver;
+}
 
-    observer.observe(linkRef.current);
-    return () => observer.disconnect();
-  }, [href, prefetchOnVisible]);
+export function PrefetchLink({ href, prefetchOnVisible = true, onMouseEnter, onFocus, ...props }: PrefetchLinkProps) {
+  const router = useRouter();
+  const linkRef = useRef<HTMLAnchorElement | null>(null);
+
+  const prefetch = useCallback(() => {
+    if (typeof href !== "string" || prefetched.has(href)) {
+      return;
+    }
+    prefetched.add(href);
+    router.prefetch(href);
+  }, [href, router]);
+
+  useEffect(() => {
+    const element = linkRef.current;
+    if (!prefetchOnVisible || !element || typeof href !== "string" || prefetched.has(href)) {
+      return;
+    }
+
+    const observer = getSharedObserver();
+    if (!observer) {
+      return;
+    }
+
+    targets.set(element, prefetch);
+    observer.observe(element);
+    return () => {
+      observer.unobserve(element);
+      targets.delete(element);
+    };
+  }, [href, prefetchOnVisible, prefetch]);
 
   return (
     <Link


### PR DESCRIPTION
## Summary

Replaces the per-instance `IntersectionObserver` in `PrefetchLink` with a single
shared observer plus a per-destination dedup guard. This is an **efficiency
cleanup, not a bug fix** — investigation (below) showed the feared prefetch
"burst" doesn't exist at the network layer, but the component was still
allocating one observer per instance (11 on the landing page) and issuing
`router.prefetch()` calls redundant with what Next `<Link>` already does.

## Investigation

Measured on a production build (`next build --webpack && next start`, Next 16.2.7),
driving the `router.prefetch()` path with real hover events and counting RSC
requests via the Performance Resource Timing API.

| Scenario | RSC prefetch requests |
|---|---|
| Hover 1 link (`/dashboard`) | 5 |
| Hover all 4 nav links | 17 (`/bridge`×5, others ×4) |
| Hover a 2nd link to an already-prefetched route | 0 |
| Same test, after this change | 17 — identical |

**Findings:**
- Next.js **dedupes `router.prefetch()` per route**. A second link to an
  already-prefetched route makes 0 new requests, and this change leaves the
  total unchanged (17→17) — so the per-instance observers and manual prefetch
  calls were never adding network requests.
- The ~4–5 requests *per route* are Next's own prefetch (a partial tree-only
  response + the full-page RSC), intrinsic to Next and independent of this
  component.
- Prefetch volume is bounded by **distinct routes**, not link count — so even a
  long list of links (e.g. a future `TransactionHistory`) can't fan out beyond
  one prefetch per unique destination.

## What changed

`src/components/prefetch-link.tsx`:
- One module-level shared `IntersectionObserver` for all instances (N→1) instead
  of one per component.
- A module-level `Set` so each `href` is prefetched at most once, regardless of
  how many instances point at it or how often they enter view / are hovered.
- Public API and behavior unchanged (eager 200px `rootMargin`, hover/focus
  prefetch, `prefetchOnVisible` prop).

## Verification

- `npm run build` ✅ · `tsc --noEmit` ✅ · `eslint` ✅ (no warnings) · `vitest` 58/58 ✅
- Re-measured after the change: no network regression (17→17).

## Notes / follow-ups

- Next `<Link>` already prefetches on viewport-entry and hover/focus in
  production, so this component is largely redundant. A future cleanup could drop
  the custom observer + manual `router.prefetch()` entirely and rely on native
  `<Link>` prefetch (only loss: the extra-eager 200px margin vs. Next's ~0px).
- Out of scope but found during testing: `next dev` currently 500s on every route
  (`FeatureFlagPanel` reads `useFeatureFlags()` during SSR in dev). Tracked
  separately.
  Closes #235