### PR TITLE
perf: memoize provider/CEX lookups and fee math to avoid per-keystrok…

### DIFF
--- a/src/components/routes/cex-page.tsx
+++ b/src/components/routes/cex-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Building2, Copy, Check, ExternalLink, Wallet } from "lucide-react";
 import { CEX_LIST } from "@/lib/types";
 
@@ -15,7 +15,7 @@ export default function CexPage() {
     setTimeout(() => setCopiedField(null), 2000);
   };
 
-  const withdrawalUrl = selectedCex.withdrawalUrl;
+  const withdrawalUrl = useMemo(() => selectedCex.withdrawalUrl, [selectedCex]);
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">

--- a/src/components/routes/onramp-page.tsx
+++ b/src/components/routes/onramp-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { CreditCard, Wallet, ExternalLink, ArrowRight, Check, DollarSign, AlertCircle } from "lucide-react";
 import { isValidStellarAddress, isCAddress } from "@/lib/stellar";
 
@@ -43,11 +43,31 @@ export default function OnrampPage() {
   const validAmount = !fiatAmount || /^\d+(\.\d{1,2})?$/.test(fiatAmount);
   const canProceed = cAddress && fiatAmount && validAddress && validAmount;
 
+  const provider = useMemo(
+    () => providers.find((p) => p.id === selectedProvider),
+    [selectedProvider]
+  );
+
+  const feeAmount = useMemo(
+    () =>
+      fiatAmount
+        ? (Number(fiatAmount) * (selectedProvider === "moonpay" ? 0.045 : 0.05)).toFixed(2)
+        : "0",
+    [fiatAmount, selectedProvider]
+  );
+
+  const estReceive = useMemo(
+    () =>
+      fiatAmount && validAmount
+        ? `~${(Number(fiatAmount) * 0.95 * (selectedProvider === "moonpay" ? 1 : 0.95)).toFixed(2)} USDC`
+        : "—",
+    [fiatAmount, validAmount, selectedProvider]
+  );
+
   const handleProviderRedirect = () => {
     if (!canProceed) return;
     setError(null);
 
-    const provider = providers.find((p) => p.id === selectedProvider);
     if (!provider) return;
 
     if (!provider.apiKey) {
@@ -71,8 +91,6 @@ export default function OnrampPage() {
       window.open(url, "_blank", "noopener,noreferrer");
     }, 1500);
   };
-
-  const provider = providers.find((p) => p.id === selectedProvider);
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -160,17 +178,11 @@ export default function OnrampPage() {
                   </div>
                   <div className="flex justify-between text-sm mt-1">
                     <span className="text-[var(--text-muted)]">Fee ({provider?.fee})</span>
-                    <span>
-                      -${fiatAmount ? (Number(fiatAmount) * (selectedProvider === "moonpay" ? 0.045 : 0.05)).toFixed(2) : "0"}
-                    </span>
+                    <span>-${feeAmount}</span>
                   </div>
                   <div className="flex justify-between text-sm mt-1">
                     <span className="text-[var(--text-muted)]">Est. receive</span>
-                    <span className="font-semibold">
-                      {fiatAmount && validAmount
-                        ? `~${(Number(fiatAmount) * 0.95 * (selectedProvider === "moonpay" ? 1 : 0.95)).toFixed(2)} USDC`
-                        : "—"}
-                    </span>
+                    <span className="font-semibold">{estReceive}</span>
                   </div>
                 </div>
 


### PR DESCRIPTION
onramp-page.tsx recomputed providers.find((p) => p.id === selectedProvider) on every render — including every keystroke in the amount field — and ran the fee/estimate math inline in JSX on each render. cex-page.tsx had a similar derived-value pattern with selectedCex.

None of this is expensive today (providers/CEX_LIST are tiny arrays), but it re-derives values on unrelated re-renders and gets more costly if either list grows. This wraps the lookups and derived math in useMemo keyed on their real dependencies, matching the memoization pattern already used in transaction-history.tsx.

Changes
src/components/routes/onramp-page.tsx

Memoized the provider lookup on [selectedProvider].
Extracted the inline fee/estimate math into memoized feeAmount ([fiatAmount, selectedProvider]) and estReceive ([fiatAmount, validAmount, selectedProvider]).
Removed a duplicate providers.find(...) — the redirect handler now reuses the single memoized provider.
src/components/routes/cex-page.tsx

Memoized withdrawalUrl on [selectedCex] for consistency (small array, minor win).
Dependency arrays satisfy react-hooks/exhaustive-deps.
closes #236