### PR TITLE
perf: Cache account balances with a short shared TTL to dedupe cross-…

### DIFF
--- a/src/__tests__/stellar.test.ts
+++ b/src/__tests__/stellar.test.ts
@@ -1,5 +1,22 @@
-import { describe, it, expect } from "vitest";
-import { isValidStellarAddress, isCAddress, isGAddress } from "@/lib/stellar";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  isValidStellarAddress,
+  isCAddress,
+  isGAddress,
+  getAccountBalances,
+  clearAccountBalancesCache,
+} from "@/lib/stellar";
+
+// Shared mock for the Horizon server's loadAccount. Hoisted so the vi.mock
+// factory (itself hoisted above the imports) can reference it safely.
+const { loadAccount } = vi.hoisted(() => ({ loadAccount: vi.fn() }));
+
+vi.mock("@stellar/stellar-sdk", () => {
+  class Server {
+    loadAccount = loadAccount;
+  }
+  return { Horizon: { Server } };
+});
 
 const G_ADDRESS = "GAIUIQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5A";
 const C_ADDRESS = "CAIUIQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5A";
@@ -48,5 +65,105 @@ describe("isGAddress", () => {
 
   it("rejects C-address", () => {
     expect(isGAddress(C_ADDRESS)).toBe(false);
+  });
+});
+
+describe("getAccountBalances cache", () => {
+  const account = (xlm: string) => ({
+    balances: [{ asset_type: "native", balance: xlm }],
+  });
+
+  beforeEach(() => {
+    clearAccountBalancesCache();
+    loadAccount.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("parses the native balance into total", async () => {
+    loadAccount.mockResolvedValue(account("100.5"));
+
+    const result = await getAccountBalances(G_ADDRESS, "TESTNET");
+
+    expect(result.total).toBe("100.5");
+    expect(result.balances).toEqual([{ asset: "XLM", amount: "100.5" }]);
+  });
+
+  it("serves back-to-back calls within the TTL from cache", async () => {
+    loadAccount.mockResolvedValue(account("100"));
+
+    const first = await getAccountBalances(G_ADDRESS, "TESTNET");
+    const second = await getAccountBalances(G_ADDRESS, "TESTNET");
+
+    expect(first.total).toBe("100");
+    expect(second.total).toBe("100");
+    expect(loadAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches once the TTL has elapsed", async () => {
+    loadAccount.mockResolvedValue(account("100"));
+    await getAccountBalances(G_ADDRESS, "TESTNET");
+
+    vi.advanceTimersByTime(11_000);
+    loadAccount.mockResolvedValue(account("200"));
+    const result = await getAccountBalances(G_ADDRESS, "TESTNET");
+
+    expect(result.total).toBe("200");
+    expect(loadAccount).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches per address:network key", async () => {
+    loadAccount.mockResolvedValue(account("100"));
+
+    await getAccountBalances(G_ADDRESS, "TESTNET");
+    await getAccountBalances(G_ADDRESS, "PUBLIC");
+
+    // Same address, different network -> distinct cache entries.
+    expect(loadAccount).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates concurrent in-flight requests", async () => {
+    let resolve!: (value: unknown) => void;
+    loadAccount.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      })
+    );
+
+    const p1 = getAccountBalances(G_ADDRESS, "TESTNET");
+    const p2 = getAccountBalances(G_ADDRESS, "TESTNET");
+    resolve(account("77"));
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1.total).toBe("77");
+    expect(r2.total).toBe("77");
+    expect(loadAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the fallback and does not cache failures", async () => {
+    loadAccount.mockRejectedValueOnce(new Error("network down"));
+
+    const failed = await getAccountBalances(G_ADDRESS, "TESTNET");
+    expect(failed).toEqual({ total: "0", balances: [] });
+
+    // Next call within the TTL must retry rather than serve the fallback.
+    loadAccount.mockResolvedValue(account("50"));
+    const recovered = await getAccountBalances(G_ADDRESS, "TESTNET");
+
+    expect(recovered.total).toBe("50");
+    expect(loadAccount).toHaveBeenCalledTimes(2);
+  });
+
+  it("clearAccountBalancesCache forces a refetch", async () => {
+    loadAccount.mockResolvedValue(account("100"));
+    await getAccountBalances(G_ADDRESS, "TESTNET");
+
+    clearAccountBalancesCache();
+    await getAccountBalances(G_ADDRESS, "TESTNET");
+
+    expect(loadAccount).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -138,22 +138,85 @@ interface HorizonPayment {
   transaction_hash?: string;
 }
 
-export async function getAccountBalances(
+/**
+ * Short-lived shared cache for account balances, keyed on `address:network`.
+ *
+ * Both the Bridge page ("Use connected wallet" check) and the Dashboard
+ * (mount + 30s poll) fetch balances for the same connected address. Without a
+ * shared cache, navigating between these pages triggers a fresh Horizon
+ * round-trip even when the data was fetched seconds earlier.
+ *
+ * The TTL is deliberately short: staleness is bounded to BALANCE_CACHE_TTL_MS,
+ * and it stays well under the Dashboard's 30s poll interval so the poll still
+ * refetches fresh data on every tick. Entries store the in-flight promise, so
+ * concurrent callers within the window share a single request; failed fetches
+ * are evicted so the fallback value is never served from cache.
+ */
+const BALANCE_CACHE_TTL_MS = 10_000; // 10 seconds
+
+interface BalanceCacheEntry {
+  promise: Promise<AccountBalances>;
+  fetchedAt: number;
+}
+
+const balanceCache = new Map<string, BalanceCacheEntry>();
+
+async function loadAccountBalances(
   address: string,
   network: "PUBLIC" | "TESTNET"
 ): Promise<AccountBalances> {
   const server = await getHorizonServer(network);
+  const account = await server.loadAccount(address);
+  const balances = (account.balances as HorizonBalance[]).map((b) => ({
+    asset: b.asset_type === "native" ? "XLM" : (b.asset_code || "unknown"),
+    amount: b.balance,
+  }));
+  const total = balances.find((b) => b.asset === "XLM")?.amount || "0";
+  return { total, balances };
+}
+
+async function withBalanceFallback(
+  promise: Promise<AccountBalances>
+): Promise<AccountBalances> {
   try {
-    const account = await server.loadAccount(address);
-    const balances = (account.balances as HorizonBalance[]).map((b) => ({
-      asset: b.asset_type === "native" ? "XLM" : (b.asset_code || "unknown"),
-      amount: b.balance,
-    }));
-    const total = balances.find((b) => b.asset === "XLM")?.amount || "0";
-    return { total, balances };
+    return await promise;
   } catch {
     return { total: "0", balances: [] };
   }
+}
+
+export async function getAccountBalances(
+  address: string,
+  network: "PUBLIC" | "TESTNET"
+): Promise<AccountBalances> {
+  const key = `${address}:${network}`;
+  const now = Date.now();
+
+  const cached = balanceCache.get(key);
+  if (cached && now - cached.fetchedAt < BALANCE_CACHE_TTL_MS) {
+    return withBalanceFallback(cached.promise);
+  }
+
+  const promise = loadAccountBalances(address, network);
+  balanceCache.set(key, { promise, fetchedAt: now });
+
+  // Evict on failure so the "0 balance" fallback is not served from cache and
+  // the next call retries against the network.
+  promise.catch(() => {
+    if (balanceCache.get(key)?.promise === promise) {
+      balanceCache.delete(key);
+    }
+  });
+
+  return withBalanceFallback(promise);
+}
+
+/**
+ * Clears the account-balances cache. Primarily for tests; call sites rely on
+ * the short TTL rather than manual invalidation.
+ */
+export function clearAccountBalancesCache(): void {
+  balanceCache.clear();
 }
 
 export async function fetchRecentTransactions(


### PR DESCRIPTION
##Summary
Cache account balances with a short shared TTL to dedupe cross-page fetches

Bridge and Dashboard both call getAccountBalances for the same connected
address with no shared cache, so navigating between them refetches balance
data the Dashboard's 30s poll may have just fetched.

Add a transparent TTL cache inside getAccountBalances keyed on
address:network (10s, well under the poll interval so polling still
refreshes). The cache stores the in-flight promise to dedupe concurrent
callers, and evicts failed fetches so the "0 balance" fallback is never
served from cache. Call sites are unchanged.

Add tests covering TTL hit/expiry, per-key isolation, concurrent dedup,
failure eviction, and manual clearing.

##What I did
I added a short-lived shared cache to getAccountBalances in src/lib/stellar.ts, modeled on sequenceManager.ts's TTL cache.

Key design decision: the cache is transparent — no changes to the call sites. Because both consumers (bridge/page.tsx:35 and dashboard-page.tsx:26) already funnel through getAccountBalances, caching inside that function makes all three paths (Bridge's "Use connected wallet" check, Dashboard mount, Dashboard 30s poll) dedupe automatically, with zero risk to the consumer components.

##How it works:

Keyed on address:network so switching wallet or network never serves stale cross-context data.
10s TTL (BALANCE_CACHE_TTL_MS), documented inline. Deliberately well under the Dashboard's 30s poll interval, so each poll tick still refetches fresh data — the cache only collapses back-to-back cross-page navigation, not the ongoing poll.
In-flight dedup: the cache stores the pending promise, so two simultaneous callers share one Horizon request.
Failures are evicted, not cached: a failed fetch removes its entry so the next call retries against the network, and the { total: "0", balances: [] } fallback is never served from cache. The function's never-throws contract is preserved via withBalanceFallback.
Added clearAccountBalancesCache() (used by tests; mirrors clearAllSequenceCache).

closes: #237 