### PR TITLE
docs: document sequence-number caching invariant (#252) and add Horizon/RPC/Testnet guidance (#253)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The onboarding layer for Soroban dApps. Fund any Soroban smart account (C-addres
    | `NEXT_PUBLIC_MOONPAY_API_KEY` | For onramp | From [Moonpay dashboard](https://buy.moonpay.com) |
    | `NEXT_PUBLIC_TRANSAK_API_KEY` | For onramp | From [Transak dashboard](https://global.transak.com) |
 
+   > **Note — Horizon and Soroban RPC endpoints:**
+   > Horizon URLs are **hardcoded constants** in `src/lib/types.ts` (`HORIZON_URL`) and are not configurable via environment variables. They always resolve to `https://horizon.stellar.org` (PUBLIC) or `https://horizon-testnet.stellar.org` (TESTNET). Soroban RPC URLs for TESTNET also default to the SDF endpoint (`https://soroban-testnet.stellar.org`) but can be overridden via the env vars above. Soroban RPC for PUBLIC is empty by default — you must provide your own provider URL. See [Sequence Number Caching](docs/sequence-numbers.md) for details on how network requests are managed.
+
 3. Run:
 
    ```bash
@@ -87,6 +90,28 @@ src/
     ├── stellar.ts         # Stellar SDK + Freighter integration
     └── types.ts           # TypeScript types and constants
 ```
+
+## Testing against Testnet
+
+To test locally against Stellar Testnet, make sure both the app and your Freighter wallet are pointed at the same network. Mismatched network settings cause confusing failures (e.g. transactions referencing the wrong Horizon server or signing with the wrong network passphrase).
+
+1. **Set the env var** in `.env.local`:
+   ```bash
+   NEXT_PUBLIC_STELLAR_NETWORK=TESTNET
+   ```
+2. **Switch Freighter to Testnet**: open the Freighter extension, click the network selector, and choose **Testnet**.
+3. **Fund a test account**: use the [Stellar Testnet Friendbot](https://friendbot.stellar.org) to fund your G-address before testing.
+4. **Run the app**: `npm run dev`.
+
+If you want to use a custom Soroban RPC provider for Testnet (e.g. for performance or reliability testing), also set:
+
+```bash
+NEXT_PUBLIC_SOROBAN_RPC_URL_TESTNET=https://your-custom-rpc.example.com
+```
+
+The Horizon endpoint cannot be overridden — it is always `https://horizon-testnet.stellar.org` when `NEXT_PUBLIC_STELLAR_NETWORK=TESTNET`.
+
+> **Important:** Both Freighter and the app must be on the **same** network. If Freighter is set to Mainnet while the app is set to TESTNET (or vice versa), transaction signing will fail or submit to the wrong network.
 
 ## How It Works
 

--- a/docs/sequence-numbers.md
+++ b/docs/sequence-numbers.md
@@ -1,0 +1,64 @@
+# Sequence Number Caching Strategy
+
+This document describes the invariant that `src/lib/sequenceManager.ts` maintains, why it matters, and how to verify it hasn't regressed.
+
+## The invariant
+
+`getNextSequenceNumber(accountId, server)` **always returns the next unused sequence number** — i.e. the sequence number the caller must use in the transaction they are about to build and submit.
+
+Concretely:
+
+| Scenario | What `getNextSequenceNumber` returns |
+|---|---|
+| **Cache miss** (no entry or TTL expired) | `networkSequence + 1` where `networkSequence` is the value the network currently has on record for this account. |
+| **Cache hit** (within 30 s TTL) | The previously cached value **+ 1**, incremented in place before returning. |
+
+This means the caller (typically `buildSignAndSubmit` in `src/lib/stellar.ts`) receives a value that is **directly usable** as the `sequence` argument to `new Account(sourceAddress, sequence)`. It does **not** need to add or subtract anything.
+
+### The `Account` constructor caveat
+
+The Stellar SDK's `Account` constructor expects the **current** on-chain sequence number, not the "next" one. Because `getNextSequenceNumber` returns the next-to-use value, the call site must subtract `1n` before passing it to `Account`:
+
+```ts
+const sequence = await getSequence();
+const account = new Account(sourceAddress, (sequence - 1n).toString());
+```
+
+This subtraction is intentional and is the **only** place in the codebase where it happens. Every other consumer of the returned value uses it as-is.
+
+## Why this matters
+
+Stellar transactions require an exact, non-repeating sequence number. If two transactions for the same account are submitted with the same sequence number, the second one fails with `tx_bad_seq`. Worse, if the cached value drifts from what the network actually has (e.g. because another client submitted a transaction for the same account), the transaction will be rejected until the cache is invalidated and re-fetched.
+
+The off-by-one class of bug — returning `networkSequence` instead of `networkSequence + 1`, or failing to increment on cache hits — has been a real source of incorrect behaviour. This document exists to prevent regressions.
+
+## How the cache works
+
+1. **First call** for an account → fetches from Horizon or Soroban RPC, stores `networkSequence + 1` with a timestamp.
+2. **Subsequent calls within `CACHE_TTL_MS` (30 s)** → increments the cached value by `1n` and returns it. No network call.
+3. **Calls after TTL expires** → re-fetches from network and restarts the cycle.
+4. **`bad_seq` error** → `withSequenceRetry` calls `invalidateSequenceCache(accountId)`, which deletes the cache entry. The retry triggers a fresh network fetch.
+
+## Call-site contract
+
+Anyone calling `getNextSequenceNumber` or working with `withSequenceRetry` must preserve these rules:
+
+- **Do not** adjust the returned value (add/subtract) except at the `Account` constructor site (`stellar.ts:349`).
+- **Do not** cache the result in a local variable and submit two transactions with the same value — each call to `getNextSequenceNumber` is intended for exactly one transaction.
+- **Do** call `invalidateSequenceCache(accountId)` if you know the account's sequence has been altered externally (e.g. a `tx_bad_seq` error).
+- **Do** use `withSequenceRetry` for any transaction submission to get automatic bad_seq recovery.
+
+## Regression tests
+
+The following test suites guard this invariant:
+
+| Test file | What it verifies |
+|---|---|
+| `src/__tests__/sequenceManager.test.ts` | Unit-level: cache hit increments correctly, cache miss fetches from network, TTL expiry triggers re-fetch, `invalidateSequenceCache` forces re-fetch, `withSequenceRetry` retries on bad_seq and invalidates between attempts. |
+| `src/__tests__/stellar-sequence-integration.test.ts` | End-to-end: `buildAndSubmitPayment` uses consecutive, strictly-incrementing sequence numbers (100, 101) across two calls, and handles TTL expiry by re-fetching the fresh network sequence (102) without collision. |
+
+Run both suites to verify the invariant:
+
+```bash
+npm run test -- --run src/__tests__/sequenceManager.test.ts src/__tests__/stellar-sequence-integration.test.ts
+```


### PR DESCRIPTION
# docs: Document sequence-number caching strategy and add network configuration guidance

## Summary

This PR addresses two documentation gaps identified in issues #252 and #253:

1. **#252 — Sequence-number caching invariant**: Creates `docs/sequence-numbers.md` documenting the exact contract that `getNextSequenceNumber` fulfils, how callers should consume the returned value (including the `Account` constructor subtraction), and pointers to the regression tests that guard the invariant.
2. **#253 — README network configuration guidance**: Expands the README environment variable section to explain that Horizon URLs are hardcoded constants (not configurable via env vars), clarifies which Soroban RPC URLs are configurable, and adds a "Testing against Testnet" walkthrough covering the Freighter + env var alignment requirement.

---

## Changes

### `docs/sequence-numbers.md` — #252 (new file)

- Explains the core invariant: `getNextSequenceNumber` always returns the **next unused** sequence number, i.e. `networkSequence + 1` on cache miss, or `cachedValue + 1n` on cache hit.
- Documents the `Account` constructor caveat (`sequence - 1n` subtraction at `stellar.ts:349`) and clarifies this is the **only** place the adjustment happens.
- Describes the cache lifecycle: first call fetches from network, subsequent calls within the 30 s TTL increment locally, TTL expiry triggers re-fetch, `bad_seq` triggers invalidation.
- Lists the call-site contract rules: do not adjust the value except at the `Account` site, do not reuse a value across two transactions, do call `invalidateSequenceCache` on known external sequence changes.
- References both `src/__tests__/sequenceManager.test.ts` (unit-level) and `src/__tests__/stellar-sequence-integration.test.ts` (end-to-end) as regression tests, with the exact command to run them.

### `README.md` — #253

- Added a **"Note — Horizon and Soroban RPC endpoints"** callout inside the environment variable table explaining that Horizon URLs are hardcoded constants in `src/lib/types.ts` (`HORIZON_URL`) and are not configurable. Notes that Soroban RPC for TESTNET defaults to the SDF endpoint but can be overridden, while PUBLIC is empty by default.
- Added a full **"Testing against Testnet"** section covering:
  1. Setting `NEXT_PUBLIC_STELLAR_NETWORK=TESTNET` in `.env.local`
  2. Switching Freighter to Testnet (same network requirement)
  3. Funding a test account via Friendbot
  4. Optional: overriding `NEXT_PUBLIC_SOROBAN_RPC_URL_TESTNET` for custom providers
  5. A bold warning that Freighter and the app must be on the **same** network to avoid signing failures

---

## Why these changes matter

### #252 — Preventing sequence-number regressions

The sequence-number cache is the single most correctness-critical piece of logic in the app. An off-by-one bug in this area was already discovered and fixed once (tracked elsewhere in this wave). Without a single, findable document explaining the invariant, the same class of bug can quietly regress when a future contributor modifies the caching logic without understanding the contract. This doc serves as both onboarding material and a regression-prevention safety net.

### #253 — Reducing contributor friction

A new contributor trying to test a fix against a different Soroban RPC provider has no documented way to discover that Horizon endpoints are hardcoded constants rather than env-configurable. The README's environment table listed `NEXT_PUBLIC_STELLAR_NETWORK` but didn't explain how it actually flows through to the Horizon/RPC URLs, or that Freighter must be set to the same network. This PR fills that gap.

---

## Files changed

```
docs/sequence-numbers.md   (new)
README.md                  (updated)
```

---

## Testing

- Markdown linting: both files render correctly in GitHub's markdown preview.
- No code changes; all existing tests remain unaffected.
- Pre-existing typecheck errors in `src/__tests__/stellar.test.ts` are unrelated to this PR.

---

Closes #252
Closes #253
