### PR TITLE
refactor: consolidate duplicate BridgeTransaction/BridgeTransactionDa…

### DIFF
--- a/src/components/routes/dashboard-page.tsx
+++ b/src/components/routes/dashboard-page.tsx
@@ -6,7 +6,7 @@ import { useWallet } from "@/components/wallet-provider";
 import TransactionHistory from "@/components/transaction-history";
 import Link from "next/link";
 import { getAccountBalances, fetchRecentTransactions, getExplorerUrl } from "@/lib/stellar";
-import type { BridgeTransactionData as BridgeTransaction } from "@/lib/stellar";
+import type { BridgeTransactionData } from "@/lib/types";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
 // Content check for the 30s poll: transaction fields are derived from
@@ -14,7 +14,7 @@ import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 // transactions exist (id) and their status. When nothing changed we keep the
 // previous array reference so memoized <TransactionHistory> can skip its
 // re-render entirely.
-function areTransactionsEqual(a: BridgeTransaction[], b: BridgeTransaction[]): boolean {
+function areTransactionsEqual(a: BridgeTransactionData[], b: BridgeTransactionData[]): boolean {
   if (a === b) return true;
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
@@ -27,7 +27,7 @@ export default function DashboardPage() {
   const { isConnected, address, network, connect } = useWallet();
   const { status: copyStatus, copy: copyToClipboard } = useCopyToClipboard();
   const [balance, setBalance] = useState<string | null>(null);
-  const [transactions, setTransactions] = useState<BridgeTransaction[]>([]);
+  const [transactions, setTransactions] = useState<BridgeTransactionData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/components/transaction-history.tsx
+++ b/src/components/transaction-history.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from "react";
 import { ArrowLeftRight, CreditCard, Building2, ExternalLink, Loader2 } from "lucide-react";
-import type { BridgeTransactionData } from "@/lib/stellar";
+import type { BridgeTransactionData } from "@/lib/types";
 import { getExplorerUrl } from "@/lib/stellar";
 import type { StellarNetwork } from "@/lib/types";
 

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -15,7 +15,7 @@ import {
   Account,
   StrKey,
 } from "@stellar/stellar-sdk";
-import { BRIDGE_CONTRACT_ID, HORIZON_URL, SOROBAN_RPC_URL, type StellarNetwork } from "./types";
+import { BRIDGE_CONTRACT_ID, HORIZON_URL, SOROBAN_RPC_URL, type StellarNetwork, type BridgeTransactionData } from "./types";
 import { withSequenceRetry } from "./sequenceManager";
 
 export async function getHorizonServer(network: StellarNetwork): Promise<Horizon.Server> {
@@ -114,19 +114,6 @@ export interface AccountBalances {
   balances: { asset: string; amount: string }[];
   /** True when the account does not exist on-chain (unfunded). (#293) */
   unfunded?: boolean;
-}
-
-export interface BridgeTransactionData {
-  id: string;
-  fromAddress: string;
-  toAddress: string;
-  amount: string;
-  asset: string;
-  status: "pending" | "confirmed" | "failed";
-  timestamp: number;
-  type: "g-to-c" | "fiat" | "cex";
-  hash?: string;
-  memo?: string;
 }
 
 interface HorizonBalance {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,7 @@ export interface WalletState {
   isConnected: boolean;
 }
 
-export interface BridgeTransaction {
+export interface BridgeTransactionData {
   id: string;
   fromAddress: string;
   toAddress: string;
@@ -17,6 +17,7 @@ export interface BridgeTransaction {
   timestamp: number;
   type: "g-to-c" | "fiat" | "cex";
   hash?: string;
+  memo?: string;
 }
 
 export interface Balance {


### PR DESCRIPTION
…ta types (#248)

Move the canonical BridgeTransactionData definition (the more complete one, with hash + memo) from stellar.ts to types.ts as the single source of truth. Remove the now-redundant BridgeTransaction interface from types.ts.

- src/lib/types.ts: replace BridgeTransaction with BridgeTransactionData (adds memo field, otherwise identical fields)
- src/lib/stellar.ts: import BridgeTransactionData from types.ts; remove the local interface definition
- src/components/transaction-history.tsx: import BridgeTransactionData from @/lib/types instead of @/lib/stellar
- src/components/routes/dashboard-page.tsx: import BridgeTransactionData from @/lib/types; remove the BridgeTransaction alias

npm run typecheck: 0 errors in the four changed files (pre-existing test errors in __tests__/ are unrelated to this change).
closes #248