### PR TITLE
fix: network-scoped sequence cache, honest network detection, working…

### DIFF
--- a/src/__tests__/bridge-asset-and-caddress.test.ts
+++ b/src/__tests__/bridge-asset-and-caddress.test.ts
@@ -51,7 +51,11 @@ describe("asset resolution honors the requested assetCode (#285)", () => {
 
     vi.mocked(freighter.signTransaction).mockImplementation(async (xdr: string) => ({
       signedTxXdr: xdr,
+      signerAddress: G_SOURCE,
     }));
+    // The source must be Freighter's active account or the payment is refused
+    // before it is ever built. (#287)
+    vi.mocked(freighter.getAddress).mockResolvedValue({ address: G_SOURCE } as never);
 
     loadAccountMock.mockResolvedValue({
       sequenceNumber: () => "100",
@@ -98,6 +102,59 @@ describe("asset resolution honors the requested assetCode (#285)", () => {
     await expect(
       buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "SHITCOIN", "TESTNET")
     ).rejects.toThrow(/trustline/i);
+  });
+});
+
+// Regression coverage for #287: Freighter signs with its active account, so a
+// transaction sourced from any other address can only fail at submission with
+// tx_bad_auth. The signing prompt must be unreachable in that case.
+describe("source address must be Freighter's active account (#287)", () => {
+  const OTHER_ACCOUNT = Keypair.random().publicKey();
+
+  beforeEach(() => {
+    // The freighter mocks are module-level, so call history survives across
+    // describe blocks unless it is cleared explicitly.
+    vi.clearAllMocks();
+    vi.mocked(freighter.signTransaction).mockImplementation(async (xdr: string) => ({
+      signedTxXdr: xdr,
+      signerAddress: G_SOURCE,
+    }));
+    vi.mocked(freighter.getAddress).mockResolvedValue({ address: OTHER_ACCOUNT } as never);
+    loadAccountMock.mockResolvedValue({
+      sequenceNumber: () => "100",
+      balances: [{ asset_type: "native", balance: "1000" }],
+    });
+    submitTransactionMock.mockResolvedValue({ hash: "mock-hash", successful: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    loadAccountMock.mockReset();
+    submitTransactionMock.mockReset();
+  });
+
+  it("rejects with an actionable message naming both accounts", async () => {
+    await expect(
+      buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "TESTNET")
+    ).rejects.toThrow(/doesn't match the From address/);
+  });
+
+  it("never reaches Freighter's signing prompt", async () => {
+    await expect(
+      buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "TESTNET")
+    ).rejects.toThrow();
+
+    expect(freighter.signTransaction).not.toHaveBeenCalled();
+    expect(submitTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("allows the payment once the active account matches", async () => {
+    vi.mocked(freighter.getAddress).mockResolvedValue({ address: G_SOURCE } as never);
+
+    const result = await buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "TESTNET");
+
+    expect(result.hash).toBe("mock-hash");
+    expect(freighter.signTransaction).toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/sequenceManager.test.ts
+++ b/src/__tests__/sequenceManager.test.ts
@@ -33,7 +33,7 @@ describe("sequenceManager", () => {
       const mockAccount = { sequenceNumber: () => "100" };
       (mockHorizonServer.loadAccount as Mock).mockResolvedValue(mockAccount);
 
-      const result = await getNextSequenceNumber(testAccountId, mockHorizonServer);
+      const result = await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET");
 
       expect(result).toBe(101n);
       expect(mockHorizonServer.loadAccount).toHaveBeenCalledWith(testAccountId);
@@ -43,8 +43,8 @@ describe("sequenceManager", () => {
       const mockAccount = { sequenceNumber: () => "100" };
       (mockHorizonServer.loadAccount as Mock).mockResolvedValue(mockAccount);
 
-      const first = await getNextSequenceNumber(testAccountId, mockHorizonServer);
-      const second = await getNextSequenceNumber(testAccountId, mockHorizonServer);
+      const first = await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET");
+      const second = await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET");
 
       expect(first).toBe(101n);
       expect(second).toBe(102n);
@@ -57,7 +57,7 @@ describe("sequenceManager", () => {
 
       const results = [];
       for (let i = 0; i < 5; i++) {
-        results.push(await getNextSequenceNumber(testAccountId, mockHorizonServer));
+        results.push(await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET"));
       }
 
       expect(results).toEqual([101n, 102n, 103n, 104n, 105n]);
@@ -69,7 +69,7 @@ describe("sequenceManager", () => {
       (mockHorizonServer.loadAccount as Mock).mockResolvedValue(mockAccount);
 
       // First call
-      await getNextSequenceNumber(testAccountId, mockHorizonServer);
+      await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET");
 
       // Advance time past TTL (30 seconds)
       vi.advanceTimersByTime(31_000);
@@ -80,7 +80,7 @@ describe("sequenceManager", () => {
       });
 
       // Second call after TTL should refetch
-      const result = await getNextSequenceNumber(testAccountId, mockHorizonServer);
+      const result = await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET");
 
       expect(result).toBe(201n);
       expect(mockHorizonServer.loadAccount).toHaveBeenCalledTimes(2);
@@ -90,10 +90,137 @@ describe("sequenceManager", () => {
       const mockAccount = { sequenceNumber: () => "100" };
       (mockSorobanRpcServer.getAccount as Mock).mockResolvedValue(mockAccount);
 
-      const result = await getNextSequenceNumber(testAccountId, mockSorobanRpcServer);
+      const result = await getNextSequenceNumber(testAccountId, mockSorobanRpcServer, "TESTNET");
 
       expect(result).toBe(101n);
       expect(mockSorobanRpcServer.getAccount).toHaveBeenCalledWith(testAccountId);
+    });
+  });
+
+  // Regression for #290: the cache used to be keyed on the account address
+  // alone, so the same G-address served (and incremented) the other chain's
+  // sequence after a Freighter network switch inside the 30s TTL.
+  describe("network scoping", () => {
+    it("keeps the same address independent across networks", async () => {
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
+        sequenceNumber: () => "100",
+      });
+
+      const testnetSeq = await getNextSequenceNumber(
+        testAccountId,
+        mockHorizonServer,
+        "TESTNET"
+      );
+      expect(testnetSeq).toBe(101n);
+
+      // Mainnet holds an unrelated sequence for the same address.
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
+        sequenceNumber: () => "5000",
+      });
+
+      const publicSeq = await getNextSequenceNumber(
+        testAccountId,
+        mockHorizonServer,
+        "PUBLIC"
+      );
+
+      // Separate fetch, and no increment of the testnet entry.
+      expect(publicSeq).toBe(5001n);
+      expect(mockHorizonServer.loadAccount).toHaveBeenCalledTimes(2);
+    });
+
+    it("increments each network's entry independently within the TTL", async () => {
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
+        sequenceNumber: () => "100",
+      });
+      await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET");
+
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
+        sequenceNumber: () => "5000",
+      });
+      await getNextSequenceNumber(testAccountId, mockHorizonServer, "PUBLIC");
+
+      // Back to testnet inside the TTL: continues the testnet series, not the
+      // mainnet one (the old behaviour returned 5002n here).
+      const nextTestnet = await getNextSequenceNumber(
+        testAccountId,
+        mockHorizonServer,
+        "TESTNET"
+      );
+      const nextPublic = await getNextSequenceNumber(
+        testAccountId,
+        mockHorizonServer,
+        "PUBLIC"
+      );
+
+      expect(nextTestnet).toBe(102n);
+      expect(nextPublic).toBe(5002n);
+      expect(mockHorizonServer.loadAccount).toHaveBeenCalledTimes(2);
+    });
+
+    it("invalidates only the (network, account) pair", async () => {
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
+        sequenceNumber: () => "100",
+      });
+      await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET");
+
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
+        sequenceNumber: () => "5000",
+      });
+      await getNextSequenceNumber(testAccountId, mockHorizonServer, "PUBLIC");
+
+      invalidateSequenceCache(testAccountId, "TESTNET");
+
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
+        sequenceNumber: () => "200",
+      });
+
+      // Testnet re-fetches...
+      expect(
+        await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET")
+      ).toBe(201n);
+      // ...while mainnet still serves its untouched cached entry.
+      expect(
+        await getNextSequenceNumber(testAccountId, mockHorizonServer, "PUBLIC")
+      ).toBe(5002n);
+      expect(mockHorizonServer.loadAccount).toHaveBeenCalledTimes(3);
+    });
+
+    it("withSequenceRetry invalidates only the network it ran on", async () => {
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
+        sequenceNumber: () => "5000",
+      });
+      await getNextSequenceNumber(testAccountId, mockHorizonServer, "PUBLIC");
+
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
+        sequenceNumber: () => "100",
+      });
+
+      const badSeqError = {
+        response: { data: { extras: { result_codes: { transaction: "tx_bad_seq" } } } },
+      };
+
+      let calls = 0;
+      const fn = vi.fn(async (getSequence: () => Promise<bigint>) => {
+        await getSequence();
+        calls++;
+        if (calls === 1) throw badSeqError;
+        return "success";
+      });
+
+      const promise = withSequenceRetry(
+        testAccountId,
+        fn,
+        mockHorizonServer,
+        "TESTNET"
+      );
+      await vi.runAllTimersAsync();
+      await promise;
+
+      // The mainnet entry survived the testnet retry's invalidation.
+      expect(
+        await getNextSequenceNumber(testAccountId, mockHorizonServer, "PUBLIC")
+      ).toBe(5002n);
     });
   });
 
@@ -103,10 +230,10 @@ describe("sequenceManager", () => {
       (mockHorizonServer.loadAccount as Mock).mockResolvedValue(mockAccount);
 
       // Fetch and cache
-      await getNextSequenceNumber(testAccountId, mockHorizonServer);
+      await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET");
 
       // Invalidate cache
-      invalidateSequenceCache(testAccountId);
+      invalidateSequenceCache(testAccountId, "TESTNET");
 
       // Update mock to return different sequence
       (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
@@ -114,7 +241,7 @@ describe("sequenceManager", () => {
       });
 
       // Next call should refetch
-      const result = await getNextSequenceNumber(testAccountId, mockHorizonServer);
+      const result = await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET");
 
       expect(result).toBe(201n);
       expect(mockHorizonServer.loadAccount).toHaveBeenCalledTimes(2);
@@ -128,11 +255,11 @@ describe("sequenceManager", () => {
       const accountId2 = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBTUMXBQ";
 
       // Fetch both accounts
-      await getNextSequenceNumber(accountId1, mockHorizonServer);
-      await getNextSequenceNumber(accountId2, mockHorizonServer);
+      await getNextSequenceNumber(accountId1, mockHorizonServer, "TESTNET");
+      await getNextSequenceNumber(accountId2, mockHorizonServer, "TESTNET");
 
       // Invalidate only accountId1
-      invalidateSequenceCache(accountId1);
+      invalidateSequenceCache(accountId1, "TESTNET");
 
       // Update mock
       (mockHorizonServer.loadAccount as Mock).mockResolvedValue({
@@ -140,11 +267,11 @@ describe("sequenceManager", () => {
       });
 
       // Next call for accountId1 should refetch
-      const result1 = await getNextSequenceNumber(accountId1, mockHorizonServer);
+      const result1 = await getNextSequenceNumber(accountId1, mockHorizonServer, "TESTNET");
       expect(result1).toBe(201n);
 
       // Next call for accountId2 should use cache (102n from cached 101n)
-      const result2 = await getNextSequenceNumber(accountId2, mockHorizonServer);
+      const result2 = await getNextSequenceNumber(accountId2, mockHorizonServer, "TESTNET");
       expect(result2).toBe(102n);
     });
   });
@@ -199,7 +326,7 @@ describe("sequenceManager", () => {
 
       const fn = vi.fn().mockResolvedValue("success");
 
-      const result = await withSequenceRetry(testAccountId, fn, mockHorizonServer);
+      const result = await withSequenceRetry(testAccountId, fn, mockHorizonServer, "TESTNET");
 
       expect(result).toBe("success");
       expect(fn).toHaveBeenCalledTimes(1);
@@ -225,7 +352,7 @@ describe("sequenceManager", () => {
       fn.mockRejectedValueOnce(badSeqError);
       fn.mockResolvedValueOnce("success");
 
-      const promise = withSequenceRetry(testAccountId, fn, mockHorizonServer);
+      const promise = withSequenceRetry(testAccountId, fn, mockHorizonServer, "TESTNET");
       await vi.runAllTimersAsync();
       const result = await promise;
 
@@ -260,7 +387,7 @@ describe("sequenceManager", () => {
         return "success";
       });
 
-      const promise = withSequenceRetry(testAccountId, fn, mockHorizonServer);
+      const promise = withSequenceRetry(testAccountId, fn, mockHorizonServer, "TESTNET");
       await vi.runAllTimersAsync();
       await promise;
 
@@ -277,7 +404,7 @@ describe("sequenceManager", () => {
       const fn = vi.fn().mockRejectedValue(nonSeqError);
 
       await expect(
-        withSequenceRetry(testAccountId, fn, mockHorizonServer)
+        withSequenceRetry(testAccountId, fn, mockHorizonServer, "TESTNET")
       ).rejects.toThrow("Transaction failed: insufficient balance");
 
       expect(fn).toHaveBeenCalledTimes(1);
@@ -301,7 +428,7 @@ describe("sequenceManager", () => {
 
       const fn = vi.fn().mockRejectedValue(badSeqError);
 
-      const promise = withSequenceRetry(testAccountId, fn, mockHorizonServer, 2);
+      const promise = withSequenceRetry(testAccountId, fn, mockHorizonServer, "TESTNET", 2);
       const expectation = expect(promise).rejects.toEqual(badSeqError);
       await vi.runAllTimersAsync();
       await expectation;
@@ -321,7 +448,7 @@ describe("sequenceManager", () => {
         return "success";
       });
 
-      await withSequenceRetry(testAccountId, fn, mockHorizonServer);
+      await withSequenceRetry(testAccountId, fn, mockHorizonServer, "TESTNET");
 
       expect(capturedSequence).toBe(101n);
     });
@@ -346,7 +473,7 @@ describe("sequenceManager", () => {
       fn.mockRejectedValueOnce(badSeqError);
       fn.mockResolvedValueOnce("success");
 
-      const promise = withSequenceRetry(testAccountId, fn, mockHorizonServer);
+      const promise = withSequenceRetry(testAccountId, fn, mockHorizonServer, "TESTNET");
 
       // Advance time to trigger retry
       await vi.advanceTimersToNextTimerAsync();
@@ -366,8 +493,8 @@ describe("sequenceManager", () => {
       const accountId2 = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBTUMXBQ";
 
       // Fetch both accounts
-      await getNextSequenceNumber(accountId1, mockHorizonServer);
-      await getNextSequenceNumber(accountId2, mockHorizonServer);
+      await getNextSequenceNumber(accountId1, mockHorizonServer, "TESTNET");
+      await getNextSequenceNumber(accountId2, mockHorizonServer, "TESTNET");
 
       // Clear all cache
       clearAllSequenceCache();
@@ -378,8 +505,8 @@ describe("sequenceManager", () => {
       });
 
       // Both should refetch
-      const result1 = await getNextSequenceNumber(accountId1, mockHorizonServer);
-      const result2 = await getNextSequenceNumber(accountId2, mockHorizonServer);
+      const result1 = await getNextSequenceNumber(accountId1, mockHorizonServer, "TESTNET");
+      const result2 = await getNextSequenceNumber(accountId2, mockHorizonServer, "TESTNET");
 
       expect(result1).toBe(201n);
       expect(result2).toBe(201n);

--- a/src/__tests__/stellar-sequence-integration.test.ts
+++ b/src/__tests__/stellar-sequence-integration.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Keypair } from "@stellar/stellar-sdk";
 import { buildAndSubmitPayment } from "@/lib/stellar";
 import { clearAllSequenceCache } from "@/lib/sequenceManager";
 import * as freighter from "@stellar/freighter-api";
-import * as stellarLib from "@/lib/stellar";
 
-const G_SOURCE = "GAIUIQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5A";
-const G_DEST = "GBIUIQ7G3TMN53Z2Y3Y5CJI7Q7ZQJX4W5F5N5Z5Q5Z5Q5Z5Q5Z5Q5Z5B";
+const G_SOURCE = Keypair.random().publicKey();
+const G_DEST = Keypair.random().publicKey();
 
 vi.mock("@stellar/freighter-api", () => ({
   signTransaction: vi.fn(),
@@ -14,32 +14,66 @@ vi.mock("@stellar/freighter-api", () => ({
   getNetwork: vi.fn(),
 }));
 
-describe("Sequence number consumption end-to-end", () => {
-  let networkSequence = "100";
-  let submittedSequences: string[] = [];
+/**
+ * Sequence numbers keyed by the Horizon URL the server was constructed with —
+ * i.e. by network. The same G-address holds completely unrelated sequences on
+ * testnet and mainnet, which is the whole point of #290; a single shared
+ * counter here would make that bug untestable.
+ */
+const networkSequence: Record<string, string> = {};
+const loadAccountCalls: string[] = [];
+const submitted: { network: string; sequence: string }[] = [];
 
+function networkOf(url: string): string {
+  return url.includes("horizon-testnet") ? "TESTNET" : "PUBLIC";
+}
+
+// Replace only Horizon.Server's network calls; the rest of the SDK stays real
+// so the transaction is genuinely built, signed and rebuilt from XDR.
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@stellar/stellar-sdk")>();
+  return {
+    ...actual,
+    Horizon: {
+      ...actual.Horizon,
+      Server: vi.fn().mockImplementation(function MockHorizonServer(
+        this: Record<string, unknown>,
+        url: string
+      ) {
+        const network = networkOf(url);
+        this.loadAccount = async () => {
+          loadAccountCalls.push(network);
+          return {
+            sequenceNumber: () => networkSequence[network],
+            balances: [{ asset_type: "native", balance: "1000" }],
+          };
+        };
+        this.fetchBaseFee = async () => 100;
+        this.submitTransaction = async (tx: { sequence: string }) => {
+          submitted.push({ network, sequence: String(tx.sequence) });
+          return { hash: "mock-tx-hash", successful: true };
+        };
+      }),
+    },
+  };
+});
+
+describe("Sequence number consumption end-to-end", () => {
   beforeEach(() => {
     clearAllSequenceCache();
-    networkSequence = "100";
-    submittedSequences = [];
+    networkSequence.TESTNET = "100";
+    networkSequence.PUBLIC = "5000";
+    loadAccountCalls.length = 0;
+    submitted.length = 0;
     vi.useFakeTimers();
 
-    vi.mocked(freighter.signTransaction).mockImplementation(async (xdr: string) => {
-      return { signedTxXdr: xdr };
-    });
-
-    const mockHorizonServer = {
-      loadAccount: vi.fn().mockImplementation(async () => ({
-        sequenceNumber: () => networkSequence,
-        balances: [{ asset_type: "native", balance: "1000" }],
-      })),
-      submitTransaction: vi.fn().mockImplementation(async (tx: any) => {
-        submittedSequences.push(String(tx.sequence));
-        return { hash: "mock-tx-hash" };
-      }),
-    };
-
-    vi.spyOn(stellarLib, "getHorizonServer").mockResolvedValue(mockHorizonServer as any);
+    vi.mocked(freighter.signTransaction).mockImplementation(async (xdr: string) => ({
+      signedTxXdr: xdr,
+      signerAddress: G_SOURCE,
+    }));
+    // buildAndSubmitPayment refuses to build for anything but Freighter's
+    // active account. (#287)
+    vi.mocked(freighter.getAddress).mockResolvedValue({ address: G_SOURCE } as never);
   });
 
   afterEach(() => {
@@ -47,33 +81,53 @@ describe("Sequence number consumption end-to-end", () => {
     vi.restoreAllMocks();
   });
 
+  // A transaction's sequence is the account's *next* sequence, so an on-chain
+  // sequence of 100 produces a transaction numbered 101.
   it("increments sequence number strictly by 1 across consecutive payment calls", async () => {
-    // 1st call (cache miss -> fetches networkSequence 100)
     const res1 = await buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "TESTNET");
     expect(res1.successful).toBe(true);
-    expect(submittedSequences[0]).toBe("100");
+    expect(submitted[0].sequence).toBe("101");
 
-    // 2nd call (cache hit -> increments to 101)
+    // 2nd call (cache hit -> increments to 102)
     const res2 = await buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "TESTNET");
     expect(res2.successful).toBe(true);
-    expect(submittedSequences[1]).toBe("101");
+    expect(submitted[1].sequence).toBe("102");
   });
 
   it("handles cache expiration and fetches fresh sequence without collision", async () => {
-    // 1st call
     await buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "TESTNET");
-    expect(submittedSequences[0]).toBe("100");
+    expect(submitted[0].sequence).toBe("101");
 
-    // 2nd call (cache hit)
     await buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "TESTNET");
-    expect(submittedSequences[1]).toBe("101");
+    expect(submitted[1].sequence).toBe("102");
 
     // Advance past TTL (30s)
     vi.advanceTimersByTime(35_000);
-    networkSequence = "102"; // Network sequence updated after 2 transactions confirmed
+    networkSequence.TESTNET = "102"; // Network sequence updated after 2 transactions confirmed
 
-    // 3rd call (cache miss -> fetches networkSequence 102)
     await buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "TESTNET");
-    expect(submittedSequences[2]).toBe("102");
+    expect(submitted[2].sequence).toBe("103");
+  });
+
+  // #290: switching Freighter's network inside the 30s TTL used to build the
+  // second transaction from the *other* chain's cached sequence — a
+  // near-guaranteed tx_bad_seq that only reproduced intermittently.
+  it("does not carry a testnet sequence into a mainnet transaction", async () => {
+    await buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "TESTNET");
+    expect(submitted[0]).toEqual({ network: "TESTNET", sequence: "101" });
+
+    // User flips Freighter to mainnet, well inside the cache TTL.
+    vi.advanceTimersByTime(5_000);
+    await buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "PUBLIC");
+
+    expect(submitted[1]).toEqual({ network: "PUBLIC", sequence: "5001" });
+    // Each network was fetched from its own Horizon, rather than one reusing
+    // the other's cached entry.
+    expect(loadAccountCalls).toContain("TESTNET");
+    expect(loadAccountCalls).toContain("PUBLIC");
+
+    // Switching back continues the testnet series where it left off.
+    await buildAndSubmitPayment(G_SOURCE, G_DEST, "10", "XLM", "TESTNET");
+    expect(submitted[2]).toEqual({ network: "TESTNET", sequence: "102" });
   });
 });

--- a/src/__tests__/walletDisconnect.test.tsx
+++ b/src/__tests__/walletDisconnect.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createRoot, Root } from "react-dom/client";
+import { WalletProvider } from "@/components/wallet-provider";
+import Navbar from "@/components/navbar";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5V3VQ";
+const CHIP = `${ADDRESS.slice(0, 4)}...${ADDRESS.slice(-4)}`;
+
+// Freighter stays connected throughout — that is the whole point of #288: the
+// poller kept re-reading it and silently undoing the user's disconnect.
+vi.mock("@/lib/stellar", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/stellar")>();
+  return {
+    formatNetworkLabel: actual.formatNetworkLabel,
+    checkConnection: vi.fn(async () => true),
+    getWalletAddress: vi.fn(async () => ADDRESS),
+    getWalletNetwork: vi.fn(async () => ({ status: "TESTNET", name: "TESTNET" })),
+    connectWallet: vi.fn(async () => ADDRESS),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/bridge",
+  useRouter: () => ({ push: vi.fn(), prefetch: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("Wallet disconnect control (#288)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const query = <T extends Element>(selector: string) => container.querySelector<T>(selector);
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <WalletProvider>
+          <Navbar />
+        </WalletProvider>
+      );
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  const advance = async (ms: number) => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+  };
+
+  const click = async (el: Element | null) => {
+    expect(el).not.toBeNull();
+    await act(async () => {
+      (el as HTMLElement).click();
+    });
+  };
+
+  const openMobileMenu = async () => {
+    await click(query('button[aria-controls="mobile-menu"]'));
+  };
+
+  it("renders a disconnect control on desktop when connected", () => {
+    expect(container.textContent).toContain(CHIP);
+    expect(query('button[aria-label="Disconnect wallet"]')).not.toBeNull();
+  });
+
+  it("renders a keyboard-focusable disconnect control in the mobile menu", async () => {
+    await openMobileMenu();
+
+    const menu = query("#mobile-menu");
+    expect(menu?.textContent).toContain("Disconnect Wallet");
+
+    // A real <button>, so it is reachable by keyboard without extra tabindex.
+    const mobileDisconnect = Array.from(menu!.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Disconnect Wallet")
+    );
+    expect(mobileDisconnect).toBeDefined();
+    expect(mobileDisconnect!.getAttribute("disabled")).toBeNull();
+  });
+
+  it("stays disconnected past several poll intervals", async () => {
+    await click(query('button[aria-label="Disconnect wallet"]'));
+    expect(container.textContent).not.toContain(CHIP);
+
+    // The poller ticks every 3s and backs off to 10s; 15s covers several ticks.
+    await advance(15_000);
+
+    expect(container.textContent).not.toContain(CHIP);
+    expect(container.textContent).toContain("Connect Wallet");
+  });
+
+  it("disconnects from the mobile menu and stays disconnected", async () => {
+    await openMobileMenu();
+    const mobileDisconnect = Array.from(query("#mobile-menu")!.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Disconnect Wallet")
+    );
+
+    await click(mobileDisconnect!);
+    await advance(15_000);
+
+    expect(container.textContent).not.toContain(CHIP);
+  });
+
+  it("reconnects when the user explicitly connects again", async () => {
+    await click(query('button[aria-label="Disconnect wallet"]'));
+    await advance(5_000);
+    expect(container.textContent).not.toContain(CHIP);
+
+    const connectButton = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Connect Wallet")
+    );
+    await click(connectButton!);
+
+    expect(container.textContent).toContain(CHIP);
+
+    // …and polling resumes: connect() cleared the sticky flag rather than
+    // merely bypassing it once.
+    await advance(10_000);
+    expect(container.textContent).toContain(CHIP);
+  });
+});

--- a/src/__tests__/walletNetwork.test.ts
+++ b/src/__tests__/walletNetwork.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as freighter from "@stellar/freighter-api";
+import {
+  getCurrentNetwork,
+  getWalletNetwork,
+  formatNetworkLabel,
+  assertActiveAccountMatches,
+} from "@/lib/stellar";
+import { isSupportedNetwork } from "@/lib/types";
+
+vi.mock("@stellar/freighter-api", () => ({
+  isConnected: vi.fn(),
+  getAddress: vi.fn(),
+  signTransaction: vi.fn(),
+  getNetwork: vi.fn(),
+}));
+
+const getNetwork = vi.mocked(freighter.getNetwork);
+const getAddress = vi.mocked(freighter.getAddress);
+
+const ACTIVE = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5V3VQ";
+const OTHER = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBTUMXBQ";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// #289: every non-PUBLIC value — including Futurenet and a failed query — used
+// to collapse into "TESTNET", so the app read the wrong chain and built
+// transactions with the wrong passphrase while confidently displaying "Testnet".
+describe("getCurrentNetwork", () => {
+  it("returns PUBLIC for a mainnet wallet", async () => {
+    getNetwork.mockResolvedValue({ network: "PUBLIC", networkPassphrase: "p" } as never);
+
+    await expect(getCurrentNetwork()).resolves.toBe("PUBLIC");
+  });
+
+  it("returns TESTNET for a testnet wallet", async () => {
+    getNetwork.mockResolvedValue({ network: "TESTNET", networkPassphrase: "p" } as never);
+
+    await expect(getCurrentNetwork()).resolves.toBe("TESTNET");
+  });
+
+  it("returns UNSUPPORTED for FUTURENET rather than pretending it's testnet", async () => {
+    getNetwork.mockResolvedValue({ network: "FUTURENET", networkPassphrase: "p" } as never);
+
+    await expect(getCurrentNetwork()).resolves.toBe("UNSUPPORTED");
+  });
+
+  it("returns UNSUPPORTED for a custom/standalone network", async () => {
+    getNetwork.mockResolvedValue({ network: "STANDALONE", networkPassphrase: "p" } as never);
+
+    await expect(getCurrentNetwork()).resolves.toBe("UNSUPPORTED");
+  });
+
+  it("returns UNKNOWN when the query throws", async () => {
+    getNetwork.mockRejectedValue(new Error("Freighter is locked"));
+
+    await expect(getCurrentNetwork()).resolves.toBe("UNKNOWN");
+  });
+
+  it("returns UNKNOWN when Freighter reports an in-band error", async () => {
+    getNetwork.mockResolvedValue({ network: "", error: "User declined access" } as never);
+
+    await expect(getCurrentNetwork()).resolves.toBe("UNKNOWN");
+  });
+
+  it("normalises lower-case network names", async () => {
+    getNetwork.mockResolvedValue({ network: "public", networkPassphrase: "p" } as never);
+
+    await expect(getCurrentNetwork()).resolves.toBe("PUBLIC");
+  });
+
+  it("never reports an unsupported or unknown network as supported", async () => {
+    for (const network of ["FUTURENET", "STANDALONE", ""]) {
+      getNetwork.mockResolvedValue({ network, networkPassphrase: "p" } as never);
+      expect(isSupportedNetwork(await getCurrentNetwork())).toBe(false);
+    }
+  });
+});
+
+describe("getWalletNetwork", () => {
+  it("reports the raw network name so the UI can name it", async () => {
+    getNetwork.mockResolvedValue({ network: "futurenet", networkPassphrase: "p" } as never);
+
+    await expect(getWalletNetwork()).resolves.toEqual({
+      status: "UNSUPPORTED",
+      name: "FUTURENET",
+    });
+  });
+
+  it("has no name when the network could not be read", async () => {
+    getNetwork.mockRejectedValue(new Error("locked"));
+
+    await expect(getWalletNetwork()).resolves.toEqual({ status: "UNKNOWN", name: null });
+  });
+});
+
+describe("formatNetworkLabel", () => {
+  it("labels the supported networks", () => {
+    expect(formatNetworkLabel("PUBLIC")).toBe("Mainnet");
+    expect(formatNetworkLabel("TESTNET")).toBe("Testnet");
+  });
+
+  it("names the unsupported network when known", () => {
+    expect(formatNetworkLabel("UNSUPPORTED", "FUTURENET")).toBe("Futurenet");
+    expect(formatNetworkLabel("UNSUPPORTED", null)).toBe("Unsupported");
+  });
+
+  it("labels an unreadable network as unknown", () => {
+    expect(formatNetworkLabel("UNKNOWN")).toBe("Unknown");
+  });
+});
+
+// #287: Freighter signs with its active account, not with whatever address the
+// transaction names as its source, so a mismatch could only fail at submission
+// with an opaque tx_bad_auth.
+describe("assertActiveAccountMatches", () => {
+  it("passes when the source is the active account", async () => {
+    getAddress.mockResolvedValue({ address: ACTIVE } as never);
+
+    await expect(assertActiveAccountMatches(ACTIVE)).resolves.toBeUndefined();
+  });
+
+  it("throws before signing when the source is a different account", async () => {
+    getAddress.mockResolvedValue({ address: ACTIVE } as never);
+
+    await expect(assertActiveAccountMatches(OTHER)).rejects.toThrow(
+      /doesn't match the From address/
+    );
+  });
+
+  it("names both addresses, truncated", async () => {
+    getAddress.mockResolvedValue({ address: ACTIVE } as never);
+
+    const error = await assertActiveAccountMatches(OTHER).catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(ACTIVE.slice(0, 8));
+    expect((error as Error).message).toContain(OTHER.slice(0, 8));
+    // Truncated, not the full 56-character keys.
+    expect((error as Error).message).not.toContain(ACTIVE);
+    expect((error as Error).message).not.toContain(OTHER);
+  });
+
+  it("throws when the active account cannot be read", async () => {
+    getAddress.mockRejectedValue(new Error("locked"));
+
+    await expect(assertActiveAccountMatches(ACTIVE)).rejects.toThrow(
+      /Couldn't read Freighter's active account/
+    );
+  });
+});

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ArrowRightLeft, Wallet, Send, ArrowRight, Check, AlertCircle, Loader2, ExternalLink } from "lucide-react";
 import { useWallet } from "@/components/wallet-provider";
-import { isValidStellarAddress, isCAddress, isValidStellarAmount, bridgeViaContract, getExplorerUrl, getAccountBalances, getAccountMinimumBalance } from "@/lib/stellar";
+import { isValidStellarAddress, isCAddress, isValidStellarAmount, bridgeViaContract, getExplorerUrl, getAccountBalances, getAccountMinimumBalance, formatNetworkLabel } from "@/lib/stellar";
 import type { AccountBalances } from "@/lib/stellar";
 
 type Step = "form" | "review" | "confirm";
@@ -18,8 +18,20 @@ const BRIDGING_UNAVAILABLE_MESSAGE =
   "G → C bridging isn't live yet: classic Stellar payments can't reach Soroban contract addresses, and the Soroban transfer path hasn't shipped. Follow progress in issue #284.";
 
 export default function BridgePage() {
-  const { isConnected, address, network, connect } = useWallet();
-  const [fromAddress, setFromAddress] = useState("");
+  const {
+    isConnected,
+    address,
+    network,
+    networkStatus,
+    walletNetworkName,
+    isNetworkSupported,
+    connect,
+  } = useWallet();
+  // The source is always Freighter's connected account, never free text.
+  // Freighter signs with its active account regardless of what the transaction
+  // names as its source, so any other value could only ever produce a
+  // tx_bad_auth failure after the user had already approved the signature. (#287)
+  const fromAddress = address ?? "";
   const [toAddress, setToAddress] = useState("");
   const [amount, setAmount] = useState("");
   const [asset, setAsset] = useState("XLM");
@@ -31,16 +43,22 @@ export default function BridgePage() {
 
   const validFrom = !fromAddress || isValidStellarAddress(fromAddress);
   const validTo = !toAddress || (isValidStellarAddress(toAddress) && isCAddress(toAddress));
+  const networkLabel = formatNetworkLabel(networkStatus, walletNetworkName);
   const validAmount = !amount || isValidStellarAmount(amount);
+
+  // Balances are only meaningful for a connected wallet on a supported
+  // network; anything cached from before a disconnect or a switch to an
+  // unsupported network is hidden rather than shown as current. (#289)
+  const activeBalances = isConnected && isNetworkSupported ? sourceBalances : null;
 
   // Balance available for the currently-selected asset. XLM lives in `total`;
   // other assets (e.g. USDC) come from the matching entry in `balances`.
   const availableBalance =
-    sourceBalances === null
+    activeBalances === null
       ? null
       : asset === "XLM"
-        ? sourceBalances.total
-        : sourceBalances.balances.find((b) => b.asset === asset)?.amount ?? "0";
+        ? activeBalances.total
+        : activeBalances.balances.find((b) => b.asset === asset)?.amount ?? "0";
 
   // Spendable balance leaves the XLM minimum reserve untouched; the reserve is
   // only held in XLM, so non-XLM assets can be sent down to zero.
@@ -61,19 +79,31 @@ export default function BridgePage() {
   // accepts (validTo requires a C-address) can actually be bridged. See #284.
   const bridgingBlocked = Boolean(toAddress) && validTo;
 
-  const canProceed = fromAddress && toAddress && amount && validFrom && validTo && !insufficientBalance && !bridgingBlocked && txStatus === "idle";
+  const canProceed =
+    isConnected &&
+    isNetworkSupported &&
+    fromAddress &&
+    toAddress &&
+    amount &&
+    validFrom &&
+    validTo &&
+    !insufficientBalance &&
+    !bridgingBlocked &&
+    txStatus === "idle";
 
-  const handleUseConnected = () => {
-    if (address) {
-      setFromAddress(address);
-      checkBalance(address);
-    }
-  };
-
-  const checkBalance = async (addr: string) => {
-    const result = await getAccountBalances(addr, network);
-    setSourceBalances(result);
-  };
+  // Balances follow the connected account: no manual "use connected wallet"
+  // step, and a network switch re-reads them against the right chain. A slow
+  // response for the previous account/network must not overwrite fresh data.
+  useEffect(() => {
+    if (!address || !isNetworkSupported) return;
+    let cancelled = false;
+    getAccountBalances(address, network).then((result) => {
+      if (!cancelled) setSourceBalances(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [address, network, isNetworkSupported]);
 
   const handleSubmit = () => {
     if (!canProceed) return;
@@ -83,6 +113,16 @@ export default function BridgePage() {
 
   const handleConfirm = async () => {
     if (!fromAddress || !toAddress || !amount) return;
+    // Never build against a network the app only guessed at. (#289)
+    if (!isNetworkSupported) {
+      setTxError(
+        networkStatus === "UNSUPPORTED"
+          ? `Freighter is on ${networkLabel}. Switch to Testnet or Mainnet to use the bridge.`
+          : "Freighter's network couldn't be read. Unlock the extension and reload before submitting."
+      );
+      setTxStatus("error");
+      return;
+    }
     setTxStatus("signing");
     setTxError(null);
 
@@ -125,32 +165,62 @@ export default function BridgePage() {
           <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-6">
             {step === "form" && (
               <div className="space-y-6">
-                <div>
-                  <label className="block text-sm font-medium mb-2">From (G-address)</label>
-                  <div className="relative">
-                    <Wallet className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--text-muted)]" />
-                    <input
-                      type="text"
-                      value={fromAddress}
-                      onChange={(e) => {
-                        setFromAddress(e.target.value);
-                        setSourceBalances(null);
-                      }}
-                      placeholder={isConnected ? address! : "GABC...DEF or connect wallet"}
-                      className="w-full pl-10 pr-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm font-mono focus:outline-none focus:border-[var(--primary)] transition-colors"
-                      disabled={txStatus !== "idle"}
-                    />
+                {isConnected && !isNetworkSupported && (
+                  <div className="p-4 rounded-lg bg-[var(--error)]/10 border border-[var(--error)]/20 flex items-start gap-3">
+                    <AlertCircle className="w-5 h-5 text-[var(--error)] flex-shrink-0 mt-0.5" />
+                    <div>
+                      <p className="text-sm font-medium text-[var(--error)]">
+                        {networkStatus === "UNSUPPORTED"
+                          ? `Freighter is on ${networkLabel}`
+                          : "Freighter's network couldn't be read"}
+                      </p>
+                      <p className="text-xs text-[var(--text-muted)] mt-1">
+                        {networkStatus === "UNSUPPORTED"
+                          ? "Switch to Testnet or Mainnet in Freighter to use the bridge. Balances and transactions are blocked until then, because the app can't tell which chain to use."
+                          : "Unlock the Freighter extension and reload the page. Nothing is submitted while the network is unknown — assuming Testnet would build transactions for the wrong chain."}
+                      </p>
+                    </div>
                   </div>
+                )}
+
+                <div>
+                  <label htmlFor="from-address" className="block text-sm font-medium mb-2">
+                    From (connected wallet)
+                  </label>
+                  {isConnected ? (
+                    <>
+                      <div className="relative">
+                        <Wallet className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--text-muted)]" />
+                        <input
+                          id="from-address"
+                          type="text"
+                          value={fromAddress}
+                          readOnly
+                          aria-describedby="from-address-help"
+                          className="w-full pl-10 pr-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm font-mono text-[var(--text-muted)] cursor-not-allowed focus:outline-none"
+                        />
+                      </div>
+                      <p id="from-address-help" className="text-xs text-[var(--text-muted)] mt-1">
+                        Freighter signs with its active account, so the source must be the connected
+                        wallet. To send from a different account, switch accounts in Freighter.
+                      </p>
+                    </>
+                  ) : (
+                    <div className="p-4 rounded-lg bg-[var(--surface-2)] border border-dashed border-[var(--border)] flex items-center justify-between gap-3">
+                      <p className="text-xs text-[var(--text-muted)]">
+                        Connect Freighter to choose the source account.
+                      </p>
+                      <button
+                        onClick={connect}
+                        className="flex-shrink-0 inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--primary)] text-white text-xs font-medium hover:bg-[var(--primary)]/90 transition-colors"
+                      >
+                        <Wallet className="w-3.5 h-3.5" />
+                        Connect Wallet
+                      </button>
+                    </div>
+                  )}
                   {!validFrom && fromAddress && (
                     <p className="text-xs text-[var(--error)] mt-1">Invalid Stellar address</p>
-                  )}
-                  {isConnected && (
-                    <button
-                      onClick={handleUseConnected}
-                      className="text-xs text-[var(--primary-light)] mt-1 hover:underline"
-                    >
-                      Use connected wallet
-                    </button>
                   )}
                   {availableBalance !== null && (
                     <p className="text-xs text-[var(--text-muted)] mt-1">
@@ -269,7 +339,7 @@ export default function BridgePage() {
                   </div>
                   <div className="flex justify-between items-center p-4 rounded-lg bg-[var(--surface-2)]">
                     <span className="text-sm text-[var(--text-muted)]">Network</span>
-                    <span className="text-sm">{network === "PUBLIC" ? "Mainnet" : "Testnet"}</span>
+                    <span className="text-sm">{networkLabel}</span>
                   </div>
                   <div className="flex justify-between items-center p-4 rounded-lg bg-[var(--surface-2)]">
                     <span className="text-sm text-[var(--text-muted)]">Fee</span>
@@ -389,7 +459,7 @@ export default function BridgePage() {
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <span className="text-[var(--text-muted)]">Network</span>
-                <span className="font-mono text-xs">{network}</span>
+                <span className="font-mono text-xs">{isConnected ? networkStatus : network}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-[var(--text-muted)]">Bridge Contract</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,10 @@ const steps = [
   {
     step: "01",
     title: "Connect Wallet",
-    description: "Connect your Freighter wallet or enter any Stellar address.",
+    // The connected Freighter account is the only possible source: Freighter
+    // signs with its active account, so any other "from" address could only
+    // fail at submission with tx_bad_auth. (#287)
+    description: "Connect your Freighter wallet — the connected account funds the transfer.",
   },
   {
     step: "02",

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -12,9 +12,10 @@
 import React, { memo, useState, useCallback, useMemo, useRef, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Wallet, ArrowLeftRight, CreditCard, Building2, LayoutDashboard, Menu, X, AlertTriangle } from "lucide-react";
+import { Wallet, ArrowLeftRight, CreditCard, Building2, LayoutDashboard, Menu, X, AlertTriangle, LogOut } from "lucide-react";
 import { useWallet } from "./wallet-provider";
 import { PrefetchLink } from "./prefetch-link";
+import { formatNetworkLabel } from "@/lib/stellar";
 
 const navLinks = [
   { href: "/bridge", label: "Bridge", icon: ArrowLeftRight },
@@ -25,7 +26,19 @@ const navLinks = [
 
 const Navbar = () => {
   const pathname = usePathname();
-  const { isConnected, address, network, connect, isConnecting, networkMismatch, dismissNetworkMismatch } = useWallet();
+  const {
+    isConnected,
+    address,
+    network,
+    networkStatus,
+    walletNetworkName,
+    isNetworkSupported,
+    connect,
+    disconnect,
+    isConnecting,
+    networkMismatch,
+    dismissNetworkMismatch,
+  } = useWallet();
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const toggleButtonRef = useRef<HTMLButtonElement>(null);
@@ -39,6 +52,11 @@ const Navbar = () => {
     connect();
     setMobileOpen(false);
   }, [connect]);
+  const handleDisconnect = useCallback(() => disconnect(), [disconnect]);
+  const handleMobileDisconnect = useCallback(() => {
+    disconnect();
+    setMobileOpen(false);
+  }, [disconnect]);
 
   // Keyboard navigation: Handle Escape key to close mobile menu
   useEffect(() => {
@@ -72,6 +90,27 @@ const Navbar = () => {
   }, [mobileOpen]);
 
   const addressDisplay = useMemo(() => (address ? `${address.slice(0, 4)}...${address.slice(-4)}` : null), [address]);
+
+  // The badge reports what the wallet is actually on, including networks the
+  // app can't use. Rendering an unsupported network as "Testnet" is what made
+  // #289 invisible to users. (#289)
+  const networkBadge = useMemo(() => {
+    const label = formatNetworkLabel(networkStatus, walletNetworkName);
+    if (networkStatus === "PUBLIC") {
+      return { label, className: "bg-[var(--success)]/15 text-[var(--success)]", title: "Connected to Mainnet" };
+    }
+    if (networkStatus === "TESTNET") {
+      return { label, className: "bg-yellow-500/15 text-yellow-400", title: "Connected to Testnet" };
+    }
+    return {
+      label,
+      className: "bg-[var(--error)]/15 text-[var(--error)]",
+      title:
+        networkStatus === "UNSUPPORTED"
+          ? `Freighter is on ${label}, which this app does not support`
+          : "Freighter's network could not be read",
+    };
+  }, [networkStatus, walletNetworkName]);
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 border-b border-[var(--border)] bg-[var(--background)]/80 backdrop-blur-xl">
@@ -111,15 +150,19 @@ const Navbar = () => {
                 <div className="w-2 h-2 rounded-full bg-[var(--success)]" />
                 <span className="text-xs font-mono text-[var(--text-muted)]">{addressDisplay}</span>
                 <span
-                  className={`text-[0.6rem] font-semibold px-1.5 py-0.5 rounded-full uppercase tracking-wide ${
-                    network === "PUBLIC"
-                      ? "bg-[var(--success)]/15 text-[var(--success)]"
-                      : "bg-yellow-500/15 text-yellow-400"
-                  }`}
-                  title={`Connected to ${network === "PUBLIC" ? "Mainnet" : "Testnet"}`}
+                  className={`text-[0.6rem] font-semibold px-1.5 py-0.5 rounded-full uppercase tracking-wide ${networkBadge.className}`}
+                  title={networkBadge.title}
                 >
-                  {network === "PUBLIC" ? "Mainnet" : "Testnet"}
+                  {networkBadge.label}
                 </span>
+                <button
+                  onClick={handleDisconnect}
+                  aria-label="Disconnect wallet"
+                  title="Disconnect wallet"
+                  className="ml-1 p-1 rounded text-[var(--text-muted)] hover:text-[var(--foreground)] hover:bg-[var(--surface)] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]"
+                >
+                  <LogOut className="w-3.5 h-3.5" />
+                </button>
               </div>
             ) : (
               <button
@@ -145,6 +188,34 @@ const Navbar = () => {
           </div>
         </div>
       </div>
+
+      {isConnected && !isNetworkSupported && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="border-t border-[var(--error)]/30 bg-[var(--error)]/10 px-4 py-2"
+        >
+          <div className="max-w-7xl mx-auto flex items-center gap-2 text-[var(--error)] text-sm">
+            <AlertTriangle className="w-4 h-4 flex-shrink-0" />
+            <span>
+              {networkStatus === "UNSUPPORTED" ? (
+                <>
+                  <strong>Unsupported network</strong> — Freighter is on{" "}
+                  <span className="font-mono font-semibold">
+                    {formatNetworkLabel(networkStatus, walletNetworkName)}
+                  </span>
+                  . Switch to Testnet or Mainnet to use the bridge.
+                </>
+              ) : (
+                <>
+                  <strong>Network unavailable</strong> — Freighter&apos;s network couldn&apos;t be
+                  read. Unlock the extension and reload before bridging.
+                </>
+              )}
+            </span>
+          </div>
+        </div>
+      )}
 
       {networkMismatch && (
         <div
@@ -202,7 +273,27 @@ const Navbar = () => {
                 </PrefetchLink>
               );
             })}
-            {!isConnected && (
+            {isConnected ? (
+              <div className="pt-2 mt-2 border-t border-[var(--border)] space-y-2">
+                <div className="flex items-center gap-2 px-3">
+                  <div className="w-2 h-2 rounded-full bg-[var(--success)]" />
+                  <span className="text-xs font-mono text-[var(--text-muted)]">{addressDisplay}</span>
+                  <span
+                    className={`text-[0.6rem] font-semibold px-1.5 py-0.5 rounded-full uppercase tracking-wide ${networkBadge.className}`}
+                    title={networkBadge.title}
+                  >
+                    {networkBadge.label}
+                  </span>
+                </div>
+                <button
+                  onClick={handleMobileDisconnect}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg border border-[var(--border)] text-sm font-medium text-[var(--text-muted)] hover:text-[var(--foreground)] hover:bg-[var(--surface-2)] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]"
+                >
+                  <LogOut className="w-4 h-4" />
+                  Disconnect Wallet
+                </button>
+              </div>
+            ) : (
               <button
                 onClick={handleMobileConnect}
                 disabled={isConnecting}

--- a/src/components/routes/dashboard-page.tsx
+++ b/src/components/routes/dashboard-page.tsx
@@ -5,7 +5,7 @@ import { Wallet, ArrowLeftRight, CreditCard, Building2, Copy, Check, ExternalLin
 import { useWallet } from "@/components/wallet-provider";
 import TransactionHistory from "@/components/transaction-history";
 import Link from "next/link";
-import { getAccountBalances, fetchRecentTransactions, getExplorerUrl } from "@/lib/stellar";
+import { getAccountBalances, fetchRecentTransactions, getExplorerUrl, formatNetworkLabel } from "@/lib/stellar";
 import type { BridgeTransactionData as BridgeTransaction } from "@/lib/stellar";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
@@ -24,7 +24,7 @@ function areTransactionsEqual(a: BridgeTransaction[], b: BridgeTransaction[]): b
 }
 
 export default function DashboardPage() {
-  const { isConnected, address, network, connect } = useWallet();
+  const { isConnected, address, network, networkStatus, walletNetworkName, isNetworkSupported, connect } = useWallet();
   const { status: copyStatus, copy: copyToClipboard } = useCopyToClipboard();
   const [balance, setBalance] = useState<string | null>(null);
   const [transactions, setTransactions] = useState<BridgeTransaction[]>([]);
@@ -33,6 +33,12 @@ export default function DashboardPage() {
 
   useEffect(() => {
     if (!isConnected || !address) return;
+    // Don't read balances off a guessed chain: on an unsupported/unreadable
+    // network the app can't tell which Horizon is the right one, and the old
+    // testnet fallback showed an unrelated (or empty) account state. The
+    // fetched values are hidden from the UI below rather than cleared here, so
+    // the previous network's data can't be mistaken for the current one. (#289)
+    if (!isNetworkSupported) return;
     // Ignore results from any fetch that was in flight when this effect
     // re-ran (e.g. a rapid network switch). Without this, a slow response
     // for the previous network could overwrite fresh data for the current one.
@@ -66,10 +72,15 @@ export default function DashboardPage() {
       cancelled = true;
       clearInterval(interval);
     };
-  }, [isConnected, address, network]);
+  }, [isConnected, address, network, isNetworkSupported]);
 
-  const confirmedCount = transactions.filter((t) => t.status === "confirmed").length;
-  const pendingCount = transactions.filter((t) => t.status === "pending").length;
+  // Chain data is only shown for a network the app actually queried. (#289)
+  const shownTransactions = isNetworkSupported ? transactions : [];
+  const shownBalance = isNetworkSupported ? balance : null;
+  const showLoading = loading && isNetworkSupported;
+
+  const confirmedCount = shownTransactions.filter((t) => t.status === "confirmed").length;
+  const pendingCount = shownTransactions.filter((t) => t.status === "pending").length;
 
   const handleCopy = () => {
     if (!address) return;
@@ -143,8 +154,10 @@ export default function DashboardPage() {
             )}
           </div>
           <div className="text-xs text-[var(--text-muted)] mt-1">
-            {network === "PUBLIC" ? "Mainnet" : "Testnet"}
-            {address && (
+            <span className={isNetworkSupported ? undefined : "text-[var(--error)] font-medium"}>
+              {formatNetworkLabel(networkStatus, walletNetworkName)}
+            </span>
+            {address && isNetworkSupported && (
               <a
                 href={getExplorerUrl(network, "account", address)}
                 target="_blank"
@@ -160,7 +173,7 @@ export default function DashboardPage() {
 
         <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5">
           <div className="text-xs text-[var(--text-muted)] mb-1">XLM Balance</div>
-          {loading ? (
+          {showLoading ? (
             <div className="flex items-center gap-2">
               <Loader2 className="w-4 h-4 animate-spin motion-reduce:animate-none text-[var(--text-muted)]" />
               <span className="text-xs text-[var(--text-muted)]">Loading...</span>
@@ -168,7 +181,7 @@ export default function DashboardPage() {
           ) : (
             <>
               <div className="text-2xl font-bold mb-1">
-                {balance !== null ? parseFloat(balance).toFixed(2) : "—"}
+                {shownBalance !== null ? parseFloat(shownBalance).toFixed(2) : "—"}
               </div>
               <div className="text-xs text-[var(--text-muted)]">XLM</div>
             </>
@@ -177,14 +190,14 @@ export default function DashboardPage() {
 
         <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5">
           <div className="text-xs text-[var(--text-muted)] mb-1">Transactions</div>
-          {loading ? (
+          {showLoading ? (
             <div className="flex items-center gap-2">
               <Loader2 className="w-4 h-4 animate-spin motion-reduce:animate-none text-[var(--text-muted)]" />
               <span className="text-xs text-[var(--text-muted)]">Loading...</span>
             </div>
           ) : (
             <>
-              <div className="text-2xl font-bold mb-1">{transactions.length}</div>
+              <div className="text-2xl font-bold mb-1">{shownTransactions.length}</div>
               <div className="text-xs text-[var(--text-muted)]">
                 {confirmedCount} confirmed{pendingCount > 0 ? `, ${pendingCount} pending` : ""}
               </div>
@@ -234,13 +247,24 @@ export default function DashboardPage() {
         </Link>
       </div>
 
+      {!isNetworkSupported && (
+        <div
+          role="alert"
+          className="mb-6 p-4 rounded-lg bg-[var(--error)]/10 border border-[var(--error)]/20 text-sm text-[var(--error)]"
+        >
+          {networkStatus === "UNSUPPORTED"
+            ? `Freighter is on ${formatNetworkLabel(networkStatus, walletNetworkName)}, which this app doesn't support. Switch to Testnet or Mainnet to see balances and activity.`
+            : "Freighter's network couldn't be read, so no chain data is shown. Unlock the extension and reload."}
+        </div>
+      )}
+
       {error && (
         <div className="mb-6 p-4 rounded-lg bg-[var(--error)]/10 border border-[var(--error)]/20 text-sm text-[var(--error)]">
           {error}
         </div>
       )}
 
-      <TransactionHistory transactions={transactions} loading={loading} network={network} address={address ?? undefined} />
+      <TransactionHistory transactions={shownTransactions} loading={showLoading} network={network} address={address ?? undefined} />
     </div>
   );
 }

--- a/src/components/wallet-provider.tsx
+++ b/src/components/wallet-provider.tsx
@@ -1,13 +1,25 @@
 "use client";
 
 import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from "react";
-import { connectWallet, checkConnection, getWalletAddress, getCurrentNetwork } from "@/lib/stellar";
-import { APP_NETWORK, type StellarNetwork } from "@/lib/types";
+import { connectWallet, checkConnection, getWalletAddress, getWalletNetwork } from "@/lib/stellar";
+import { APP_NETWORK, isSupportedNetwork, type StellarNetwork, type WalletNetworkState } from "@/lib/types";
 
 interface WalletContextType {
   address: string | null;
   publicKey: string | null;
+  /**
+   * The network the app targets for Horizon/Soroban endpoints. Only ever a
+   * network the app supports — it holds its previous value (or APP_NETWORK)
+   * while the wallet is on an unsupported/unreadable network, which is why
+   * `networkStatus` must be consulted before building any transaction. (#289)
+   */
   network: StellarNetwork;
+  /** The wallet's actual network state, including UNSUPPORTED/UNKNOWN. (#289) */
+  networkStatus: WalletNetworkState;
+  /** Raw network name Freighter reported, e.g. "FUTURENET". Null if unreadable. */
+  walletNetworkName: string | null;
+  /** True when the wallet is on a network the app can transact on. */
+  isNetworkSupported: boolean;
   isConnected: boolean;
   isConnecting: boolean;
   /** True when the network changed mid-session (after initial connection). */
@@ -32,6 +44,13 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   // correct Horizon and Soroban RPC endpoints before a wallet is connected.
   // NEXT_PUBLIC_STELLAR_NETWORK drives this value at build time. (#302)
   const [network, setNetwork] = useState<StellarNetwork>(APP_NETWORK);
+  /**
+   * The wallet's reported network state. Starts at APP_NETWORK because no
+   * wallet has been queried yet; once a wallet is seen this can widen to
+   * UNSUPPORTED/UNKNOWN, which gates transaction building. (#289)
+   */
+  const [networkStatus, setNetworkStatus] = useState<WalletNetworkState>(APP_NETWORK);
+  const [walletNetworkName, setWalletNetworkName] = useState<string | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
   /**
    * `networkMismatch` is true when the network changed after the initial
@@ -47,29 +66,56 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const initialNetworkRef = useRef<"PUBLIC" | "TESTNET" | null>(null);
   /** Whether the user has dismissed the mismatch banner for this session. */
   const dismissedRef = useRef(false);
+  /**
+   * Sticky record of the user having pressed Disconnect. The poller runs every
+   * few seconds and would otherwise re-set the address straight back from
+   * Freighter, silently undoing the disconnect. (#288)
+   */
+  const manuallyDisconnectedRef = useRef(false);
 
   const dismissNetworkMismatch = useCallback(() => {
     dismissedRef.current = true;
     setNetworkMismatch(false);
   }, []);
 
+  /**
+   * Applies a freshly-read wallet network. `network` (the endpoint target) is
+   * only moved to networks the app supports; UNSUPPORTED/UNKNOWN are surfaced
+   * through `networkStatus` so callers block rather than transact on a guess.
+   */
+  const applyNetwork = useCallback((status: WalletNetworkState, name: string | null) => {
+    setNetworkStatus(status);
+    setWalletNetworkName(name);
+    if (isSupportedNetwork(status)) {
+      setNetwork(status);
+    }
+    return status;
+  }, []);
+
   const updateConnection = useCallback(async () => {
+    // Respect an explicit disconnect until the user reconnects. (#288)
+    if (manuallyDisconnectedRef.current) return;
+
     const isConnected = await checkConnection();
     if (isConnected) {
       const pk = await getWalletAddress();
-      const net = await getCurrentNetwork();
+      const { status, name } = await getWalletNetwork();
       setAddress(pk);
-      setNetwork(net);
+      applyNetwork(status, name);
+
+      // Mismatch tracking only makes sense between two supported networks; an
+      // unsupported/unknown network gets its own, louder notice instead.
+      if (!isSupportedNetwork(status)) return;
 
       if (initialNetworkRef.current === null) {
         // First time we see the wallet connected — record the baseline network.
-        initialNetworkRef.current = net;
-      } else if (!dismissedRef.current && net !== initialNetworkRef.current) {
+        initialNetworkRef.current = status;
+      } else if (!dismissedRef.current && status !== initialNetworkRef.current) {
         // Network changed after initial connection → surface warning.
         setNetworkMismatch(true);
         // Update the baseline so subsequent same-network polls don't re-fire,
         // but a *further* change will fire again.
-        initialNetworkRef.current = net;
+        initialNetworkRef.current = status;
       }
     } else {
       setAddress(null);
@@ -77,33 +123,40 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       initialNetworkRef.current = null;
       dismissedRef.current = false;
       setNetworkMismatch(false);
+      setNetworkStatus(APP_NETWORK);
+      setWalletNetworkName(null);
     }
-  }, []);
+  }, [applyNetwork]);
 
   const connect = useCallback(async () => {
+    // An explicit connect clears the sticky disconnect so polling resumes. (#288)
+    manuallyDisconnectedRef.current = false;
     setIsConnecting(true);
     try {
       const pk = await connectWallet();
       if (pk) {
         setAddress(pk);
-        const net = await getCurrentNetwork();
-        setNetwork(net);
+        const { status, name } = await getWalletNetwork();
+        applyNetwork(status, name);
         // Record the network at the point of explicit connection so we can
         // detect changes later in the polling loop.
-        initialNetworkRef.current = net;
+        initialNetworkRef.current = isSupportedNetwork(status) ? status : null;
         dismissedRef.current = false;
         setNetworkMismatch(false);
       }
     } finally {
       setIsConnecting(false);
     }
-  }, []);
+  }, [applyNetwork]);
 
   const disconnect = useCallback(() => {
+    manuallyDisconnectedRef.current = true;
     setAddress(null);
     initialNetworkRef.current = null;
     dismissedRef.current = false;
     setNetworkMismatch(false);
+    setNetworkStatus(APP_NETWORK);
+    setWalletNetworkName(null);
   }, []);
 
   // Polling with backoff + visibility awareness
@@ -176,6 +229,9 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         address,
         publicKey: address,
         network,
+        networkStatus,
+        walletNetworkName,
+        isNetworkSupported: isSupportedNetwork(networkStatus),
         isConnected: !!address,
         isConnecting,
         networkMismatch,

--- a/src/lib/sequenceManager.ts
+++ b/src/lib/sequenceManager.ts
@@ -1,10 +1,11 @@
 import { Horizon, rpc, Account } from "@stellar/stellar-sdk";
+import type { StellarNetwork } from "./types";
 
 /**
  * Manages Stellar account sequence numbers to prevent bad_seq errors.
  *
  * Strategy:
- * - Cache the sequence number per account after each fetch
+ * - Cache the sequence number per (network, account) after each fetch
  * - Increment locally for consecutive transactions without re-fetching
  * - Invalidate cache and re-fetch on bad_seq errors
  * - Re-fetch if cache is older than CACHE_TTL_MS
@@ -20,18 +21,32 @@ interface SequenceEntry {
 const cache = new Map<string, SequenceEntry>();
 
 /**
- * Returns the next sequence number for the given account address.
- * Fetches from network if cache is missing or expired.
+ * The same G-address exists independently on testnet and mainnet with entirely
+ * unrelated sequence numbers, so the network has to be part of the cache key.
+ * Keying on the address alone meant switching Freighter between networks within
+ * the 30s TTL served (and incremented) the *other* chain's sequence, producing
+ * intermittent tx_bad_seq failures. (#290)
+ */
+function cacheKey(accountId: string, network: StellarNetwork): string {
+  return `${network}:${accountId}`;
+}
+
+/**
+ * Returns the next sequence number for the given account address on the given
+ * network. Fetches from network if cache is missing or expired.
  * Increments the cached value for subsequent calls within TTL.
  *
  * @param accountId - Stellar public key (G... address)
  * @param server - Horizon or SorobanRpc server instance
+ * @param network - The network `server` points at ("PUBLIC" or "TESTNET")
  */
 export async function getNextSequenceNumber(
   accountId: string,
-  server: Horizon.Server | rpc.Server
+  server: Horizon.Server | rpc.Server,
+  network: StellarNetwork
 ): Promise<bigint> {
-  const entry = cache.get(accountId);
+  const key = cacheKey(accountId, network);
+  const entry = cache.get(key);
   const now = Date.now();
 
   if (entry && now - entry.fetchedAt < CACHE_TTL_MS) {
@@ -43,7 +58,7 @@ export async function getNextSequenceNumber(
   // Cache miss or expired — fetch from network
   const currentSequence = await fetchSequenceFromNetwork(accountId, server);
   const nextSequence = currentSequence + 1n;
-  cache.set(accountId, { sequence: nextSequence, fetchedAt: now });
+  cache.set(key, { sequence: nextSequence, fetchedAt: now });
   return nextSequence;
 }
 
@@ -65,13 +80,20 @@ async function fetchSequenceFromNetwork(
 }
 
 /**
- * Invalidates the cached sequence number for an account.
+ * Invalidates the cached sequence number for an account on a single network.
  * Call this when a bad_seq error is received so the next call re-fetches.
  *
+ * Only the (network, account) pair is dropped — the same address's entry on the
+ * other network is untouched, since the two sequences are unrelated. (#290)
+ *
  * @param accountId - Stellar public key to invalidate
+ * @param network - The network whose entry should be dropped
  */
-export function invalidateSequenceCache(accountId: string): void {
-  cache.delete(accountId);
+export function invalidateSequenceCache(
+  accountId: string,
+  network: StellarNetwork
+): void {
+  cache.delete(cacheKey(accountId, network));
 }
 
 /**
@@ -114,24 +136,26 @@ export function isBadSequenceError(error: unknown): boolean {
  * @param fn - Async function that builds and submits a transaction.
  *             Receives a getSequence function it should call to get the sequence.
  * @param server - Stellar server instance for re-fetching
+ * @param network - The network `server` points at ("PUBLIC" or "TESTNET")
  * @param maxRetries - Maximum number of retries on bad_seq (default: 1)
  */
 export async function withSequenceRetry<T>(
   accountId: string,
   fn: (getSequence: () => Promise<bigint>) => Promise<T>,
   server: Horizon.Server | rpc.Server,
+  network: StellarNetwork,
   maxRetries = 1
 ): Promise<T> {
   let attempts = 0;
 
   while (true) {
     try {
-      const getSequence = () => getNextSequenceNumber(accountId, server);
+      const getSequence = () => getNextSequenceNumber(accountId, server, network);
       return await fn(getSequence);
     } catch (error) {
       if (isBadSequenceError(error) && attempts < maxRetries) {
         attempts++;
-        invalidateSequenceCache(accountId);
+        invalidateSequenceCache(accountId, network);
         // Small delay before retry to avoid thundering herd
         await new Promise((resolve) => setTimeout(resolve, 200 * attempts));
         continue;

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -15,8 +15,16 @@ import {
   Account,
   StrKey,
 } from "@stellar/stellar-sdk";
-import { BRIDGE_CONTRACT_ID, HORIZON_URL, SOROBAN_RPC_URL, type StellarNetwork } from "./types";
+import {
+  BRIDGE_CONTRACT_ID,
+  HORIZON_URL,
+  SOROBAN_RPC_URL,
+  type StellarNetwork,
+  type WalletNetworkState,
+} from "./types";
 import { withSequenceRetry } from "./sequenceManager";
+
+export type { AppNetwork, WalletNetworkState } from "./types";
 
 export async function getHorizonServer(network: StellarNetwork): Promise<Horizon.Server> {
   const { Horizon } = await import("@stellar/stellar-sdk");
@@ -71,13 +79,70 @@ export async function getWalletAddress(): Promise<string | null> {
   }
 }
 
-export async function getCurrentNetwork(): Promise<StellarNetwork> {
+export interface WalletNetworkInfo {
+  /** What the app can do with the wallet's current network. */
+  status: WalletNetworkState;
+  /**
+   * The raw, upper-cased network name Freighter reported (e.g. "FUTURENET",
+   * "STANDALONE"). Null when the network could not be read at all. Used to name
+   * the actual network in the "unsupported network" notice.
+   */
+  name: string | null;
+}
+
+/**
+ * Reads the wallet's current network *without* collapsing it into the app's
+ * two-value union.
+ *
+ * Freighter can report FUTURENET, STANDALONE or any custom network, and the
+ * query itself can fail. Previously all of those became "TESTNET", so a
+ * Futurenet user saw a confident "Testnet" label, had balances read off the
+ * wrong chain, and got transactions built with the testnet passphrase — with
+ * every resulting error pointing away from the real cause. (#289)
+ */
+export async function getWalletNetwork(): Promise<WalletNetworkInfo> {
   try {
     const result = await getNetwork();
-    const networkName = String(result.network ?? "").toUpperCase();
-    return networkName === "PUBLIC" ? "PUBLIC" : "TESTNET";
+    // Freighter reports failures in-band via `error` as well as by throwing.
+    if (result && typeof result === "object" && "error" in result && result.error) {
+      return { status: "UNKNOWN", name: null };
+    }
+    const name = String(result.network ?? "").toUpperCase();
+    if (name === "PUBLIC" || name === "TESTNET") {
+      return { status: name, name };
+    }
+    return { status: "UNSUPPORTED", name: name || null };
   } catch {
-    return "TESTNET";
+    // Couldn't query the wallet — do NOT pretend it's testnet.
+    return { status: "UNKNOWN", name: null };
+  }
+}
+
+/**
+ * The wallet's current network state, including the "unsupported network" and
+ * "couldn't read the network" cases. Callers must handle all four values;
+ * see {@link WalletNetworkState}. (#289)
+ */
+export async function getCurrentNetwork(): Promise<WalletNetworkState> {
+  return (await getWalletNetwork()).status;
+}
+
+/**
+ * Human-readable label for a wallet network state, for badges and notices.
+ */
+export function formatNetworkLabel(
+  status: WalletNetworkState,
+  name?: string | null
+): string {
+  switch (status) {
+    case "PUBLIC":
+      return "Mainnet";
+    case "TESTNET":
+      return "Testnet";
+    case "UNSUPPORTED":
+      return name ? `${name.charAt(0)}${name.slice(1).toLowerCase()}` : "Unsupported";
+    case "UNKNOWN":
+      return "Unknown";
   }
 }
 
@@ -381,8 +446,43 @@ async function buildSignAndSubmit(
         successful: submitResult.successful,
       };
     },
-    server
+    server,
+    network
   );
+}
+
+/** Shortens an address for display in error messages: GABCDEFG…WXYZ. */
+function truncateAddress(address: string): string {
+  return address.length > 12
+    ? `${address.slice(0, 8)}…${address.slice(-4)}`
+    : address;
+}
+
+/**
+ * Verifies that Freighter's active account is the account that will source the
+ * transaction, *before* anything is built or signed.
+ *
+ * Freighter signs with whichever account is active, not with the account named
+ * as the transaction source. A transaction sourced from address A carrying only
+ * B's signature fails at submission with tx_bad_auth — an opaque error that
+ * says nothing about the actual mismatch. Failing here instead names both
+ * addresses and tells the user what to do. (#287)
+ */
+export async function assertActiveAccountMatches(sourceAddress: string): Promise<void> {
+  const active = await getWalletAddress();
+
+  if (!active) {
+    throw new Error(
+      "Couldn't read Freighter's active account. Connect (or unlock) Freighter and try again."
+    );
+  }
+
+  if (active !== sourceAddress) {
+    throw new Error(
+      `Freighter's active account (${truncateAddress(active)}) doesn't match the From address (${truncateAddress(sourceAddress)}). ` +
+        "Switch accounts in Freighter or use the connected address."
+    );
+  }
 }
 
 /**
@@ -419,6 +519,10 @@ export async function buildAndSubmitPayment(
   network: StellarNetwork,
   onPhase?: (phase: "signing" | "submitting") => void
 ): Promise<PaymentResult> {
+  // Defence in depth: the UI binds the From field to the connected wallet, but
+  // a mismatch here would only surface as tx_bad_auth after signing. (#287)
+  await assertActiveAccountMatches(sourceAddress);
+
   const server = await getHorizonServer(network);
   const passphrase = await getNetworkPassphrase(network);
   const asset = await resolveAsset(server, sourceAddress, assetCode);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,33 @@ export const STELLAR_NETWORK = {
 /** The set of supported Stellar network identifiers. */
 export type StellarNetwork = keyof typeof STELLAR_NETWORK;
 
+/**
+ * The networks this app is able to transact on. Alias of {@link StellarNetwork},
+ * kept as a distinct name because it reads more clearly next to
+ * {@link WalletNetworkState}, where "the app's networks" and "whatever the
+ * wallet happens to be on" are genuinely different sets. (#289)
+ */
+export type AppNetwork = StellarNetwork;
+
+/**
+ * Everything the wallet's network can actually be, from the app's point of view:
+ *
+ * - `"PUBLIC"` / `"TESTNET"` — a network the app supports
+ * - `"UNSUPPORTED"` — the wallet reported a real network the app can't use
+ *   (Futurenet, Standalone, a custom passphrase…)
+ * - `"UNKNOWN"` — the network could not be read from the wallet at all
+ *
+ * The last two must stay distinct from `"TESTNET"`: coercing them silently made
+ * a Futurenet wallet look like a genuine testnet session, so the app queried the
+ * wrong Horizon and built transactions with the wrong passphrase. (#289)
+ */
+export type WalletNetworkState = AppNetwork | "UNSUPPORTED" | "UNKNOWN";
+
+/** Narrows a wallet network state to one the app can build transactions on. */
+export function isSupportedNetwork(state: WalletNetworkState): state is AppNetwork {
+  return state === "PUBLIC" || state === "TESTNET";
+}
+
 // SDF does not operate a free public mainnet Soroban RPC, so PUBLIC must be
 // configured explicitly; getSorobanRpcServer throws a clear error if it's
 // unset rather than resolving to a non-existent hostname. TESTNET defaults to


### PR DESCRIPTION
Closes #287, Closes #288, Closes #289, Closes #290

## Summary

This PR addresses four core network-scoping, wallet-binding, sequence-caching, and session-management bugs across `C-Address-Onboarding-Bridge--Frontend-`.

---

## Key Changes

### 1. Network-Scoped Sequence Cache (#290)
- **`src/lib/sequenceManager.ts`**: Updated sequence cache key format to `${network}:${accountId}` across `getNextSequenceNumber`, `invalidateSequenceCache`, and `withSequenceRetry`.
- Ensures sequence numbers fetched on `TESTNET` do not bleed into `PUBLIC` calls (or vice versa), preventing `tx_bad_seq` failures when users toggle networks within the 30s TTL.

### 2. Explicit & Honest Network State Handling (#289)
- **`src/lib/stellar.ts` & `src/lib/types.ts`**: Refactored `getCurrentNetwork()` to return `"PUBLIC" | "TESTNET" | "UNSUPPORTED" | "UNKNOWN"` instead of silently coercing Futurenet or failed queries to `"TESTNET"`.
- **`src/components/wallet-provider.tsx` & UI**: Exposed raw network names and gated transaction building on unsupported/unknown network states with actionable UI warnings.

### 3. Sticky Wallet Disconnect (#288)
- **`src/components/wallet-provider.tsx`**: Introduced `manuallyDisconnectedRef` to ensure explicit user disconnects persist past 3-second polling intervals until `connect()` is re-invoked.
- **`src/components/navbar.tsx`**: Added accessible disconnect controls to both desktop and mobile header navigation views.

### 4. Wallet-Bound "From" Address (#287)
- **`src/app/bridge/page.tsx` & `src/lib/stellar.ts`**: Bound the "From" input field to `useWallet().address`.
- Added pre-sign active account verification (`assertActiveAccountMatches`) before invoking Freighter signing to prevent `tx_bad_auth` signature mismatches.
- Updated landing page copy in `src/app/page.tsx`.

---

## Verification

- [x] **Unit & Integration Testing**: 114 passing tests (`npx vitest run`), including new coverage for cross-network cache isolation, `getCurrentNetwork` status branches, active account matching, and polling-resilient disconnects.
- [x] **Lint & Typecheck**: Clean `tsc --noEmit` and reduced ESLint warnings across modified files.
- [x] **Build Verification**: `next build` succeeded cleanly.