### PR TITLE
fix(bridge,navbar,footer,flags): batch fixes for Stellar Wave issues #321-#324

### DIFF
--- a/src/__tests__/bridge-address-form.test.tsx
+++ b/src/__tests__/bridge-address-form.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createRoot, Root } from "react-dom/client";
+import BridgePage from "@/app/bridge/page";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@/components/wallet-provider", () => ({
+  useWallet: () => ({
+    isConnected: false,
+    address: null,
+    network: "TESTNET",
+    networkStatus: "TESTNET",
+    walletNetworkName: "Testnet",
+    isNetworkSupported: true,
+    connect: vi.fn(),
+  }),
+}));
+
+describe("Bridge page — Address Form", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    container = null;
+    root = null;
+    vi.restoreAllMocks();
+  });
+
+  it("associates the 'To (C-address)' label with its input via htmlFor/id", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<BridgePage />);
+    });
+
+    const label = Array.from(container.querySelectorAll("label")).find(
+      (el) => el.textContent === "To (C-address)"
+    ) as HTMLLabelElement;
+    expect(label).toBeTruthy();
+
+    const inputId = label.getAttribute("for");
+    expect(inputId).toBeTruthy();
+
+    const input = container.querySelector(`#${inputId}`);
+    expect(input).not.toBeNull();
+    expect(input?.tagName).toBe("INPUT");
+  });
+});

--- a/src/__tests__/feature-flag-panel-focus-trap.test.tsx
+++ b/src/__tests__/feature-flag-panel-focus-trap.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createRoot, Root } from "react-dom/client";
+import { FeatureFlagPanel } from "@/components/FeatureFlagPanel";
+import { FeatureFlagProvider } from "@/contexts/FeatureFlagContext";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("FeatureFlagPanel Tab focus trap", () => {
+  const originalEnv = process.env;
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, NODE_ENV: "development" };
+    if (typeof localStorage !== "undefined") {
+      localStorage.clear();
+    }
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    container = null;
+    root = null;
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("wraps Tab from the last focusable element to the first", async () => {
+    await act(async () => {
+      root?.render(
+        <FeatureFlagProvider>
+          <FeatureFlagPanel />
+        </FeatureFlagProvider>
+      );
+    });
+
+    const toggleButton = container?.querySelector(
+      'button[aria-label="Toggle feature flags panel"]'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      toggleButton.click();
+    });
+
+    const switches = container?.querySelectorAll('[role="switch"]');
+    expect(switches?.length).toBeGreaterThan(0);
+    const first = switches?.[0] as HTMLElement;
+    const last = switches?.[switches.length - 1] as HTMLElement;
+
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    });
+
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("wraps Shift+Tab from the first focusable element to the last", async () => {
+    await act(async () => {
+      root?.render(
+        <FeatureFlagProvider>
+          <FeatureFlagPanel />
+        </FeatureFlagProvider>
+      );
+    });
+
+    const toggleButton = container?.querySelector(
+      'button[aria-label="Toggle feature flags panel"]'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      toggleButton.click();
+    });
+
+    const switches = container?.querySelectorAll('[role="switch"]');
+    const first = switches?.[0] as HTMLElement;
+    const last = switches?.[switches.length - 1] as HTMLElement;
+
+    first.focus();
+    expect(document.activeElement).toBe(first);
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true }));
+    });
+
+    expect(document.activeElement).toBe(last);
+  });
+});

--- a/src/__tests__/footer.test.tsx
+++ b/src/__tests__/footer.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { describe, it, expect, afterEach } from "vitest";
+import { createRoot, Root } from "react-dom/client";
+import Footer from "@/components/footer";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("Footer", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    container = null;
+    root = null;
+  });
+
+  const renderFooter = async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(<Footer />);
+    });
+  };
+
+  it("renders the documented protocol links", async () => {
+    await renderFooter();
+
+    const linkHref = (name: string) =>
+      Array.from(container?.querySelectorAll("a") ?? []).find((a) => a.textContent === name)?.getAttribute("href");
+
+    expect(linkHref("G → C Bridge")).toBe("/bridge");
+    expect(linkHref("Fiat Onramp")).toBe("/onramp");
+    expect(linkHref("CEX Withdrawal")).toBe("/cex");
+  });
+
+  it("renders external resource links with safe target/rel attributes", async () => {
+    await renderFooter();
+
+    const externalLinks = Array.from(container?.querySelectorAll("a") ?? []).filter((a) =>
+      ["Soroban Docs", "GitHub", "Stellar"].includes(a.textContent ?? "")
+    );
+
+    expect(externalLinks).toHaveLength(3);
+    externalLinks.forEach((link) => {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    });
+  });
+});

--- a/src/__tests__/navbar-a11y.test.tsx
+++ b/src/__tests__/navbar-a11y.test.tsx
@@ -28,13 +28,15 @@ vi.mock("next/link", () => ({
 }));
 
 // Mock wallet provider
+const mockUseWallet = vi.fn(() => ({
+  isConnected: false,
+  address: null,
+  connect: vi.fn(),
+  isConnecting: false,
+}));
+
 vi.mock("@/components/wallet-provider", () => ({
-  useWallet: () => ({
-    isConnected: false,
-    address: null,
-    connect: vi.fn(),
-    isConnecting: false,
-  }),
+  useWallet: () => mockUseWallet(),
 }));
 
 describe("Navbar Mobile Menu A11Y & Focus Management", () => {
@@ -58,6 +60,12 @@ describe("Navbar Mobile Menu A11Y & Focus Management", () => {
     }
     container = null;
     root = null;
+    mockUseWallet.mockReturnValue({
+      isConnected: false,
+      address: null,
+      connect: vi.fn(),
+      isConnecting: false,
+    });
     vi.restoreAllMocks();
   });
 
@@ -143,6 +151,39 @@ describe("Navbar Mobile Menu A11Y & Focus Management", () => {
     expect(document.activeElement).toBe(toggleBtn);
 
     vi.useRealTimers();
+  });
+
+  it("renders an identical network badge in the desktop and mobile wallet-status displays", async () => {
+    mockUseWallet.mockReturnValue({
+      isConnected: true,
+      address: "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV",
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      isConnecting: false,
+      network: "TESTNET",
+      networkStatus: "TESTNET",
+      walletNetworkName: "Testnet",
+      isNetworkSupported: true,
+      networkMismatch: false,
+      dismissNetworkMismatch: vi.fn(),
+    });
+
+    await act(async () => {
+      root?.render(<Navbar />);
+    });
+
+    // The mobile wallet-status display only mounts while the mobile menu is open.
+    const toggleBtn = container?.querySelector('button[aria-controls="mobile-menu"]') as HTMLButtonElement;
+    await act(async () => {
+      toggleBtn.click();
+    });
+
+    const badges = container?.querySelectorAll('span[title="Connected to Testnet"]');
+    expect(badges?.length).toBe(2);
+    badges?.forEach((badge) => {
+      expect(badge.textContent).toBe("Testnet");
+      expect(badge.className).toContain("rounded-full");
+    });
   });
 
   it("restores focus to toggle button when mobile menu is closed via toggle button click", async () => {

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -261,25 +261,26 @@ export default function BridgePage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium mb-2">To (C-address)</label>
+                  <label htmlFor="to-address" className="block text-sm font-medium mb-2">To (C-address)</label>
                   <div className="relative">
                     <Send className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--text-muted)]" />
-                     <input
-                       type="text"
-                       value={toAddress}
-                       onChange={(e) => setToAddress(e.target.value)}
-                       placeholder="CABC...DEF"
-                       aria-invalid={!validTo && !!toAddress}
-                       aria-describedby={!validTo && toAddress ? "to-address-error" : undefined}
-                       className="w-full pl-10 pr-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm font-mono focus:outline-none focus:border-[var(--primary)] transition-colors"
-                       disabled={txStatus !== "idle"}
-                     />
-                   </div>
-                   {!validTo && toAddress && (
-                     <p id="to-address-error" className="text-xs text-[var(--error)] mt-1" role="alert">
-                       Invalid C-address (must start with C and be 56 characters)
-                     </p>
-                   )}
+                    <input
+                      id="to-address"
+                      type="text"
+                      value={toAddress}
+                      onChange={(e) => setToAddress(e.target.value)}
+                      placeholder="CABC...DEF"
+                      aria-invalid={!validTo && !!toAddress}
+                      aria-describedby={!validTo && toAddress ? "to-address-error" : undefined}
+                      className="w-full pl-10 pr-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm font-mono focus:outline-none focus:border-[var(--primary)] transition-colors"
+                      disabled={txStatus !== "idle"}
+                    />
+                  </div>
+                  {!validTo && toAddress && (
+                    <p id="to-address-error" className="text-xs text-[var(--error)] mt-1" role="alert">
+                      Invalid C-address (must start with C and be 56 characters)
+                    </p>
+                  )}
                 </div>
 
                 <div>

--- a/src/components/FeatureFlagPanel.tsx
+++ b/src/components/FeatureFlagPanel.tsx
@@ -20,7 +20,7 @@ import { useFeatureFlags } from "@/contexts/FeatureFlagContext";
  *
  * 3. **Keyboard Controls & Navigation**:
  *    - **Escape Key (`Escape`)**: Pressing `Escape` at any time while the panel is open closes the panel immediately and returns keyboard focus to the toggle button.
- *    - **Tab Navigation (`Tab` / `Shift+Tab`)**: Focus moves sequentially between feature flag toggle switches (`role="switch"`) and reset buttons (`title="Reset to default"`).
+ *    - **Tab Navigation (`Tab` / `Shift+Tab`)**: Focus moves sequentially between feature flag toggle switches (`role="switch"`) and reset buttons (`title="Reset to default"`), and is trapped within the dialog — tabbing past the last focusable element wraps to the first, and shift+tabbing past the first wraps to the last.
  *    - **Focus Restoration**: Closing the panel via mouse click or `Escape` key restores active focus back to the floating trigger button (`toggleButtonRef`).
  *
  * 4. **ARIA Standards**:
@@ -44,6 +44,25 @@ export function FeatureFlagPanel() {
       if (e.key === "Escape") {
         setIsOpen(false);
         toggleButtonRef.current?.focus();
+        return;
+      }
+
+      if (e.key === "Tab") {
+        const panel = panelRef.current;
+        if (!panel) return;
+        const focusable = panel.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
       }
     };
 

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,3 +1,17 @@
+/**
+ * Site-wide footer.
+ *
+ * Structure:
+ * - Brand/summary column describing the C-Address Bridge protocol.
+ * - "Protocol" column: internal links to the three funding routes
+ *   (`/bridge`, `/onramp`, `/cex`) that also appear in the navbar.
+ * - "Resources" column: external links (Soroban docs, GitHub, Stellar.org),
+ *   all opened via `target="_blank"` with `rel="noopener noreferrer"`.
+ * - A bottom bar with a disclaimer and the protocol name.
+ *
+ * Purely presentational — no state, no props. Memoized since it never
+ * changes across route navigations.
+ */
 import React, { memo } from "react";
 import { Wallet } from "lucide-react";
 

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -24,6 +24,23 @@ const navLinks = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
 ];
 
+interface NetworkBadgeProps {
+  label: string;
+  className: string;
+  title: string;
+}
+
+// Shared by the desktop and mobile wallet-status displays so the badge
+// markup only needs to be kept in sync with `networkBadge` in one place.
+const NetworkBadge = ({ label, className, title }: NetworkBadgeProps) => (
+  <span
+    className={`text-[0.6rem] font-semibold px-1.5 py-0.5 rounded-full uppercase tracking-wide ${className}`}
+    title={title}
+  >
+    {label}
+  </span>
+);
+
 const Navbar = () => {
   const pathname = usePathname();
   const {
@@ -149,12 +166,7 @@ const Navbar = () => {
               <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--surface-2)] border border-[var(--border)]">
                 <div className="w-2 h-2 rounded-full bg-[var(--success)]" />
                 <span className="text-xs font-mono text-[var(--text-muted)]">{addressDisplay}</span>
-                <span
-                  className={`text-[0.6rem] font-semibold px-1.5 py-0.5 rounded-full uppercase tracking-wide ${networkBadge.className}`}
-                  title={networkBadge.title}
-                >
-                  {networkBadge.label}
-                </span>
+                <NetworkBadge {...networkBadge} />
                 <button
                   onClick={handleDisconnect}
                   aria-label="Disconnect wallet"
@@ -278,12 +290,7 @@ const Navbar = () => {
                 <div className="flex items-center gap-2 px-3">
                   <div className="w-2 h-2 rounded-full bg-[var(--success)]" />
                   <span className="text-xs font-mono text-[var(--text-muted)]">{addressDisplay}</span>
-                  <span
-                    className={`text-[0.6rem] font-semibold px-1.5 py-0.5 rounded-full uppercase tracking-wide ${networkBadge.className}`}
-                    title={networkBadge.title}
-                  >
-                    {networkBadge.label}
-                  </span>
+                  <NetworkBadge {...networkBadge} />
                 </div>
                 <button
                   onClick={handleMobileDisconnect}


### PR DESCRIPTION
## Summary


- **closes #321** (Bug, Address Form) — the "To (C-address)" field on the Bridge form (`src/app/bridge/page.tsx`) had a `<label>` with no `htmlFor` and an `<input>` with no matching `id`, so the label was never programmatically associated with its control (clicking the label didn't focus the input, and screen readers announced it unlabelled). Fixed the association and the block's inconsistent indentation.
- **closes #322** (Enhancement, Onboarding Modal) — the app's one modal dialog, `FeatureFlagPanel` (which also toggles the `new_onboarding_flow` flag), let `Tab`/`Shift+Tab` move focus out of the dialog entirely while open. Added a focus trap so `Tab` wraps from the last focusable element to the first and `Shift+Tab` wraps from the first to the last, matching standard modal dialog behavior.
- **closes #323** (Chore, Header) — `navbar.tsx` duplicated the network-status badge markup verbatim between the desktop and mobile wallet-status displays. Extracted a small `NetworkBadge` component so the markup is defined once; no behavior change.
- **closes #324** (Docs, Footer) — `footer.tsx` had no documentation of its structure, unlike other components in this codebase (e.g. `navbar.tsx`). Added a doc comment describing its sections.

## Testing / validation performed

- Added tests for each change:
  - `src/__tests__/bridge-address-form.test.tsx` — label/input association
  - `src/__tests__/feature-flag-panel-focus-trap.test.tsx` — Tab/Shift+Tab wrap behavior
  - `src/__tests__/navbar-a11y.test.tsx` — new case asserting the desktop and mobile displays render an identical `NetworkBadge`
  - `src/__tests__/footer.test.tsx` — protocol/resource links
- `npm run lint` — 0 errors (same 8 pre-existing warnings as `main`, none in touched files)
- `npm run typecheck` / `npm run test` / `npm run build` — verified against a clean checkout of `main` that this branch introduces **no new failures**: `main` already fails `typecheck`/`build` (missing `TRANSACTION_TIMEOUT_SECONDS` constant and `BridgeTransactionData` export in `src/lib/stellar.ts`) and has 6 pre-existing failing test files (including a missing `@testing-library/react` devDependency), all unrelated to these 4 issues. This branch's own new/changed tests all pass.
