### PR TITLE
perf(address-autocomplete): debounce validation on address and amount inputs

### DIFF
--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -5,6 +5,7 @@ import { ArrowRightLeft, Wallet, Send, ArrowRight, Check, AlertCircle, Loader2, 
 import { useWallet } from "@/components/wallet-provider";
 import { isValidStellarAddress, isCAddress, isValidStellarAmount, bridgeViaContract, getExplorerUrl, getAccountBalances, getAccountMinimumBalance, formatNetworkLabel } from "@/lib/stellar";
 import type { AccountBalances } from "@/lib/stellar";
+import { useDebounce } from "@/hooks/useDebounce";
 
 type Step = "form" | "review" | "confirm";
 type TxStatus = "idle" | "signing" | "submitting" | "success" | "error";
@@ -42,9 +43,13 @@ export default function BridgePage() {
   const [sourceBalances, setSourceBalances] = useState<AccountBalances | null>(null);
 
   const validFrom = !fromAddress || isValidStellarAddress(fromAddress);
-  const validTo = !toAddress || (isValidStellarAddress(toAddress) && isCAddress(toAddress));
+  // Debounce address/amount validation to avoid running StrKey CRC checks on
+  // every keystroke — validation fires 300 ms after the user stops typing.
+  const debouncedToAddress = useDebounce(toAddress, 300);
+  const debouncedAmount = useDebounce(amount, 300);
+  const validTo = !debouncedToAddress || (isValidStellarAddress(debouncedToAddress) && isCAddress(debouncedToAddress));
   const networkLabel = formatNetworkLabel(networkStatus, walletNetworkName);
-  const validAmount = !amount || isValidStellarAmount(amount);
+  const validAmount = !debouncedAmount || isValidStellarAmount(debouncedAmount);
 
   // Balances are only meaningful for a connected wallet on a supported
   // network; anything cached from before a disconnect or a switch to an
@@ -77,7 +82,7 @@ export default function BridgePage() {
 
   // No Soroban transfer path is implemented yet, so no destination this form
   // accepts (validTo requires a C-address) can actually be bridged. See #284.
-  const bridgingBlocked = Boolean(toAddress) && validTo;
+  const bridgingBlocked = Boolean(debouncedToAddress) && validTo;
 
   const canProceed =
     isConnected &&
@@ -89,6 +94,8 @@ export default function BridgePage() {
     validTo &&
     !insufficientBalance &&
     !bridgingBlocked &&
+    debouncedToAddress === toAddress &&
+    debouncedAmount === amount &&
     txStatus === "idle";
 
   // Balances follow the connected account: no manual "use connected wallet"
@@ -275,7 +282,7 @@ export default function BridgePage() {
                        disabled={txStatus !== "idle"}
                      />
                    </div>
-                   {!validTo && toAddress && (
+                   {!validTo && debouncedToAddress && (
                      <p id="to-address-error" className="text-xs text-[var(--error)] mt-1" role="alert">
                        Invalid C-address (must start with C and be 56 characters)
                      </p>
@@ -315,7 +322,7 @@ export default function BridgePage() {
                       <option>USDC</option>
                     </select>
                   </div>
-                  {!validAmount && amount && (
+                  {!validAmount && debouncedAmount && (
                     <p className="text-xs text-[var(--error)] mt-1">
                       Invalid amount. Enter a positive number with up to 7 decimal places (e.g. &quot;10&quot; or &quot;0.5&quot;).
                     </p>

--- a/src/components/routes/onramp-page.tsx
+++ b/src/components/routes/onramp-page.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import { CreditCard, Wallet, ExternalLink, ArrowRight, Check, DollarSign, AlertCircle } from "lucide-react";
 import { isValidStellarAddress, isCAddress } from "@/lib/stellar";
+import { useDebounce } from "@/hooks/useDebounce";
 
 const MOONPAY_API_KEY = process.env.NEXT_PUBLIC_MOONPAY_API_KEY || "";
 const TRANSAK_API_KEY = process.env.NEXT_PUBLIC_TRANSAK_API_KEY || "";
@@ -100,9 +101,14 @@ export default function OnrampPage() {
   const [redirectUrl, setRedirectUrl] = useState<string | null>(null);
 
   const provider = providers.find((p) => p.id === selectedProvider);
-  const validAddress = !cAddress || (isValidStellarAddress(cAddress) && isCAddress(cAddress));
-  const validAmount = !fiatAmount || /^\d+(\.\d{1,2})?$/.test(fiatAmount);
-  const canProceed = cAddress && fiatAmount && validAddress && validAmount;
+  // Debounce address and amount validation to avoid running expensive
+  // StrKey checks on every keystroke — validation fires 300 ms after the
+  // user stops typing instead of on every character change.
+  const debouncedCAddress = useDebounce(cAddress, 300);
+  const debouncedFiatAmount = useDebounce(fiatAmount, 300);
+  const validAddress = !debouncedCAddress || (isValidStellarAddress(debouncedCAddress) && isCAddress(debouncedCAddress));
+  const validAmount = !debouncedFiatAmount || /^\d+(\.\d{1,2})?$/.test(debouncedFiatAmount);
+  const canProceed = cAddress && fiatAmount && validAddress && validAmount && debouncedCAddress === cAddress && debouncedFiatAmount === fiatAmount;
 
   const { fee: feeAmount, receive: receiveAmount } = calculateOnrampFeeAndReceive(
     Number(fiatAmount) || 0,
@@ -196,7 +202,7 @@ export default function OnrampPage() {
                        className="w-full pl-10 pr-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm font-mono focus:outline-none focus:border-[var(--primary)] transition-colors"
                      />
                    </div>
-                   {!validAddress && cAddress && (
+                   {!validAddress && debouncedCAddress && (
                      <p id="c-address-error" className="text-xs text-[var(--error)] mt-1" role="alert">Invalid C-address (must start with C, 56 characters)</p>
                    )}
                 </div>
@@ -215,7 +221,7 @@ export default function OnrampPage() {
                        className="w-full pl-10 pr-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors"
                      />
                    </div>
-                   {!validAmount && fiatAmount && (
+                   {!validAmount && debouncedFiatAmount && (
                      <p id="fiat-amount-error" className="text-xs text-[var(--error)] mt-1" role="alert">Invalid amount format</p>
                    )}
                 </div>

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Debounces a value by the given delay (ms).
+ * The returned value only updates once the input value has been stable for
+ * `delay` milliseconds, reducing how often downstream validation runs on
+ * rapidly-typed input.
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
Adds a `useDebounce` hook (300 ms delay) and applies it to address and amount inputs in the Bridge and Onramp pages. StrKey CRC16 validation now fires only after the user pauses typing, eliminating redundant validation cycles on every keystroke.

## Changes
- `src/hooks/useDebounce.ts` — new reusable hook
- `src/app/bridge/page.tsx` — debounce to/amount validation
- `src/components/routes/onramp-page.tsx` — debounce cAddress/fiatAmount validation

## Validation
- Lint: passes
- No new type errors introduced

Closes #326