### PR TITLE
a11y(validation): add missing ARIA labels, ids and role=alert to validation errors

### DIFF
--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -261,10 +261,11 @@ export default function BridgePage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium mb-2">To (C-address)</label>
+                  <label htmlFor="to-address" className="block text-sm font-medium mb-2">To (C-address)</label>
                   <div className="relative">
                     <Send className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--text-muted)]" />
                      <input
+                       id="to-address"
                        type="text"
                        value={toAddress}
                        onChange={(e) => setToAddress(e.target.value)}
@@ -283,14 +284,20 @@ export default function BridgePage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium mb-2">Amount</label>
+                  <label htmlFor="bridge-amount" className="block text-sm font-medium mb-2">Amount</label>
                   <div className="flex gap-3">
                     <div className="relative flex-1">
                       <input
+                        id="bridge-amount"
                         type="text"
                         value={amount}
                         onChange={(e) => setAmount(e.target.value)}
                         placeholder="0.00"
+                        aria-invalid={(!validAmount && !!amount) || insufficientBalance}
+                        aria-describedby={
+                          (!validAmount && amount) ? "amount-format-error" :
+                          insufficientBalance ? "amount-balance-error" : undefined
+                        }
                         className="w-full px-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors"
                         disabled={txStatus !== "idle"}
                       />
@@ -308,6 +315,7 @@ export default function BridgePage() {
                     <select
                       value={asset}
                       onChange={(e) => setAsset(e.target.value)}
+                      aria-label="Asset to send"
                       className="px-4 py-3 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors"
                       disabled={txStatus !== "idle"}
                     >
@@ -316,12 +324,12 @@ export default function BridgePage() {
                     </select>
                   </div>
                   {!validAmount && amount && (
-                    <p className="text-xs text-[var(--error)] mt-1">
+                    <p id="amount-format-error" className="text-xs text-[var(--error)] mt-1" role="alert">
                       Invalid amount. Enter a positive number with up to 7 decimal places (e.g. &quot;10&quot; or &quot;0.5&quot;).
                     </p>
                   )}
                   {insufficientBalance && (
-                    <p className="text-xs text-[var(--error)] mt-1">
+                    <p id="amount-balance-error" className="text-xs text-[var(--error)] mt-1" role="alert">
                       Insufficient balance. Available:{" "}
                       {spendableBalance !== null ? Math.max(spendableBalance, 0).toFixed(2) : "0.00"} {asset}
                       {asset === "XLM" ? " (after minimum reserve)" : ""}

--- a/src/components/routes/onramp-page.tsx
+++ b/src/components/routes/onramp-page.tsx
@@ -183,10 +183,11 @@ export default function OnrampPage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium mb-2">Destination C-Address</label>
+                  <label htmlFor="onramp-c-address" className="block text-sm font-medium mb-2">Destination C-Address</label>
                   <div className="relative">
                     <Wallet className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--text-muted)]" />
                     <input
+                       id="onramp-c-address"
                        type="text"
                        value={cAddress}
                        onChange={(e) => setCAddress(e.target.value)}
@@ -202,10 +203,11 @@ export default function OnrampPage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium mb-2">Amount (USD)</label>
+                  <label htmlFor="onramp-fiat-amount" className="block text-sm font-medium mb-2">Amount (USD)</label>
                   <div className="relative">
                     <DollarSign className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--text-muted)]" />
                     <input
+                       id="onramp-fiat-amount"
                        type="text"
                        value={fiatAmount}
                        onChange={(e) => setFiatAmount(e.target.value)}


### PR DESCRIPTION
## Summary
Improves accessibility for all validation feedback in the Bridge and Onramp pages so screen readers can announce errors immediately and correctly associate them with their inputs.

## Changes
- **Bridge page**: `htmlFor` on To/Amount labels; `id` on inputs; `aria-invalid` + `aria-describedby` + `id` + `role="alert"` on amount error paragraphs; `aria-label` on asset select
- **Onramp page**: `htmlFor` on C-address and fiat-amount labels; `id` attributes on both inputs

## Validation
- Lint: passes
- No new type errors introduced

Closes #327