### PR TITLE
test(error-handling): add unit tests for the Error page component

### DIFF
--- a/src/__tests__/errorBoundary.test.tsx
+++ b/src/__tests__/errorBoundary.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { createRoot } from "react-dom/client";
+import ErrorPage from "@/app/error";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function renderError(error: Error & { digest?: string }, reset: () => void): HTMLDivElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<ErrorPage error={error} reset={reset} />);
+  });
+  return container;
+}
+
+describe("Error page (src/app/error.tsx)", () => {
+  it("renders the error message from the Error object", () => {
+    const reset = vi.fn();
+    const container = renderError(Object.assign(new Error("Something exploded"), {}), reset);
+    expect(container.textContent).toContain("Something exploded");
+    container.remove();
+  });
+
+  it("falls back to the default message when error.message is empty", () => {
+    const reset = vi.fn();
+    const err = Object.assign(new Error(""), {});
+    const container = renderError(err, reset);
+    expect(container.textContent).toContain("An unexpected error occurred");
+    container.remove();
+  });
+
+  it("renders a Try Again button that calls reset on click", () => {
+    const reset = vi.fn();
+    const container = renderError(Object.assign(new Error("Oops"), {}), reset);
+
+    const button = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Try Again")
+    );
+    expect(button).toBeDefined();
+
+    act(() => { button!.click(); });
+    expect(reset).toHaveBeenCalledTimes(1);
+    container.remove();
+  });
+
+  it("handles an error with a digest property without crashing", () => {
+    const reset = vi.fn();
+    const err = Object.assign(new Error("Digest error"), { digest: "abc123" });
+    const container = renderError(err, reset);
+    expect(container.textContent).toContain("Digest error");
+    container.remove();
+  });
+
+  it("renders the heading 'Something went wrong'", () => {
+    const reset = vi.fn();
+    const container = renderError(Object.assign(new Error("test"), {}), reset);
+    expect(container.textContent).toContain("Something went wrong");
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
Adds a dedicated test file for `src/app/error.tsx` to improve CI coverage for the error handling component. Uses the same `jsdom` + `createRoot` pattern as the existing component tests.

## Tests added (`src/__tests__/errorBoundary.test.tsx`)
- Renders the error message from the `Error` object
- Falls back to default message when `error.message` is empty
- Try Again button calls the `reset` callback
- Handles an error with a `digest` property without crashing
- Heading "Something went wrong" is always shown

## Validation
- Lint: passes
- No new type errors introduced

Closes #329