### PR TITLE
fix(routing): navigate footer protocol links with next/link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
       "devDependencies": {
         "@next/bundle-analyzer": "^16.2.7",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -286,6 +288,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2178,6 +2190,64 @@
         "tailwindcss": "4.3.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -2188,6 +2258,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3058,6 +3135,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3856,6 +3943,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3878,6 +3975,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6193,6 +6297,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6796,6 +6910,41 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "devDependencies": {
     "@next/bundle-analyzer": "^16.2.7",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/__tests__/footer-routing.test.tsx
+++ b/src/__tests__/footer-routing.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+//
+// Routing coverage for the footer, which the root layout renders on every page.
+//
+// The footer used to navigate its Protocol links with bare <a href="/bridge">
+// anchors. Those are full document loads: the client tree is torn down, and
+// because WalletProvider keeps the session in memory only (no localStorage /
+// sessionStorage), a footer click dropped the connected address, the network
+// status, the dismissed-mismatch flag and any half-filled bridge/onramp form.
+// These tests pin the distinction so a future edit that reintroduces a raw
+// anchor for an internal route fails here.
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import Footer from "@/components/footer";
+
+// next/link is stubbed with a marker attribute — without it a rendered Link and
+// a raw anchor are indistinguishable in the DOM, which is exactly the bug.
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className} data-next-link="true">
+      {children}
+    </a>
+  ),
+}));
+
+const INTERNAL_ROUTES = ["/bridge", "/onramp", "/cex"];
+
+afterEach(cleanup);
+
+describe("Footer routing", () => {
+  it("routes every internal destination through next/link", () => {
+    render(<Footer />);
+
+    for (const route of INTERNAL_ROUTES) {
+      const link = document.querySelector(`a[href="${route}"]`);
+      expect(link, `expected a footer link to ${route}`).not.toBeNull();
+      expect(
+        link?.getAttribute("data-next-link"),
+        `${route} must use next/link, not a raw <a> (a raw anchor full-reloads and drops the wallet session)`
+      ).toBe("true");
+    }
+  });
+
+  it("leaves no same-origin anchor outside next/link", () => {
+    render(<Footer />);
+
+    const rawInternalAnchors = Array.from(document.querySelectorAll("a[href^='/']")).filter(
+      (anchor) => anchor.getAttribute("data-next-link") !== "true"
+    );
+
+    expect(rawInternalAnchors.map((anchor) => anchor.getAttribute("href"))).toEqual([]);
+  });
+
+  it("keeps external resources as plain anchors that open safely", () => {
+    render(<Footer />);
+
+    const externalAnchors = Array.from(document.querySelectorAll("a[href^='http']"));
+    expect(externalAnchors.length).toBeGreaterThan(0);
+
+    for (const anchor of externalAnchors) {
+      expect(anchor.getAttribute("data-next-link")).toBeNull();
+      expect(anchor.getAttribute("target")).toBe("_blank");
+      // noopener/noreferrer keep the opened tab from reaching window.opener.
+      expect(anchor.getAttribute("rel")).toContain("noopener");
+      expect(anchor.getAttribute("rel")).toContain("noreferrer");
+    }
+  });
+
+  it("still renders the visible labels for each protocol route", () => {
+    render(<Footer />);
+
+    expect(screen.getByText("G → C Bridge").closest("a")?.getAttribute("href")).toBe("/bridge");
+    expect(screen.getByText("Fiat Onramp").closest("a")?.getAttribute("href")).toBe("/onramp");
+    expect(screen.getByText("CEX Withdrawal").closest("a")?.getAttribute("href")).toBe("/cex");
+  });
+});

--- a/src/__tests__/notifications-a11y.test.tsx
+++ b/src/__tests__/notifications-a11y.test.tsx
@@ -1,0 +1,295 @@
+// @vitest-environment jsdom
+//
+// Accessibility coverage for the app's notification surfaces — the transient
+// status messages (clipboard feedback, fetch/validation errors, redirect
+// confirmations, loading states) that are otherwise conveyed only by swapping
+// icons, colors and inline text. Each test pins the mechanism that makes one of
+// those changes perceivable to a screen reader, so a future refactor that drops
+// a role or a live region fails here instead of silently regressing.
+import React, { act } from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { StrKey } from "@stellar/stellar-sdk";
+import LiveRegion from "@/components/live-region";
+import TransactionHistory from "@/components/transaction-history";
+import DashboardPage from "@/components/routes/dashboard-page";
+import CexPage from "@/components/routes/cex-page";
+
+const ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5V3VQ";
+// A real contract StrKey with a valid checksum, encoded from fixed bytes rather
+// than hardcoded, so isCAddress() accepts it for the right reason. (Keypair
+// .random() is unusable here: its RNG shim does not work under jsdom.)
+const VALID_C_ADDRESS = StrKey.encodeContract(Buffer.alloc(32, 7));
+
+// Only the network calls are stubbed; isCAddress and friends stay real so the
+// CEX validation path under test is the production one.
+const getAccountBalances = vi.fn();
+const fetchRecentTransactions = vi.fn();
+
+vi.mock("@/lib/stellar", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/stellar")>();
+  return {
+    ...actual,
+    getAccountBalances: (...args: unknown[]) => getAccountBalances(...args),
+    fetchRecentTransactions: (...args: unknown[]) => fetchRecentTransactions(...args),
+  };
+});
+
+const wallet = {
+  isConnected: true,
+  address: ADDRESS,
+  network: "TESTNET" as const,
+  networkStatus: "TESTNET" as const,
+  walletNetworkName: "TESTNET",
+  isNetworkSupported: true,
+  connect: vi.fn(),
+};
+
+vi.mock("@/components/wallet-provider", () => ({
+  useWallet: () => wallet,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+/** Install a clipboard whose writeText either resolves or rejects. */
+function stubClipboard(outcome: "success" | "failure") {
+  const writeText = vi.fn(() =>
+    outcome === "success" ? Promise.resolve() : Promise.reject(new Error("denied")),
+  );
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+  return writeText;
+}
+
+/** Click and flush the click handler's promise chain inside act(). */
+async function clickAndSettle(el: Element) {
+  await act(async () => {
+    fireEvent.click(el);
+  });
+}
+
+const politeText = (container: HTMLElement) =>
+  container.querySelector('[aria-live="polite"]')?.textContent ?? null;
+
+describe("LiveRegion", () => {
+  afterEach(cleanup);
+
+  it("renders a visually hidden atomic polite region by default", () => {
+    const { container } = render(<LiveRegion message="Saved." />);
+    const region = container.querySelector("[aria-live]") as HTMLElement;
+
+    expect(region).not.toBeNull();
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    expect(region.getAttribute("aria-atomic")).toBe("true");
+    expect(region.className).toContain("sr-only");
+    expect(region.textContent).toBe("Saved.");
+  });
+
+  it("honours an assertive politeness", () => {
+    const { container } = render(<LiveRegion politeness="assertive" message="Failed." />);
+    expect(container.querySelector("[aria-live]")?.getAttribute("aria-live")).toBe("assertive");
+  });
+
+  it("stays mounted while idle so the first announcement is not missed", () => {
+    // An AT that registers a live region only on insertion must see it before
+    // it has text; an empty region is the idle state, not an absent one.
+    const { container, rerender } = render(<LiveRegion message="" />);
+    const region = container.querySelector("[aria-live]");
+    expect(region).not.toBeNull();
+    expect(region?.textContent).toBe("");
+
+    rerender(<LiveRegion message="Now announcing." />);
+    expect(container.querySelector("[aria-live]")).toBe(region);
+    expect(region?.textContent).toBe("Now announcing.");
+  });
+});
+
+describe("Dashboard notifications", () => {
+  beforeEach(() => {
+    getAccountBalances.mockResolvedValue({ total: "100.0000000" });
+    fetchRecentTransactions.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  const renderDashboard = async () => {
+    let result!: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(<DashboardPage />);
+    });
+    return result;
+  };
+
+  it("names the copy button independently of its title attribute", async () => {
+    stubClipboard("success");
+    await renderDashboard();
+
+    const button = screen.getByRole("button", { name: "Copy wallet address" });
+    expect(button.getAttribute("title")).toBe("Copy address");
+  });
+
+  it("announces a successful address copy", async () => {
+    const writeText = stubClipboard("success");
+    const { container } = await renderDashboard();
+
+    expect(politeText(container)).toBe("");
+
+    await clickAndSettle(screen.getByRole("button", { name: "Copy wallet address" }));
+
+    expect(writeText).toHaveBeenCalledWith(ADDRESS);
+    expect(politeText(container)).toBe("Wallet address copied to clipboard.");
+  });
+
+  it("announces a failed address copy instead of reporting success", async () => {
+    stubClipboard("failure");
+    const { container } = await renderDashboard();
+
+    await clickAndSettle(screen.getByRole("button", { name: "Copy wallet address" }));
+
+    expect(politeText(container)).toBe("Copy failed. Check clipboard permissions and try again.");
+  });
+
+  it("announces a balance/activity fetch failure via an alert", async () => {
+    getAccountBalances.mockRejectedValue(new Error("Horizon unreachable"));
+    await renderDashboard();
+
+    // The banner arrives asynchronously — role="alert" is what makes it audible.
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("Horizon unreachable");
+  });
+});
+
+describe("CEX page notifications", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  const enterAddress = (value: string) => {
+    fireEvent.change(screen.getByLabelText("Soroban C-address"), { target: { value } });
+  };
+
+  it("announces validation success, not only failure", () => {
+    render(<CexPage />);
+
+    enterAddress("not-a-c-address");
+    expect(screen.getByRole("alert").textContent).toContain("Invalid C-address");
+
+    enterAddress(VALID_C_ADDRESS);
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain("Valid C-address");
+  });
+
+  it("announces a successful C-address copy", async () => {
+    const writeText = stubClipboard("success");
+    const { container } = render(<CexPage />);
+
+    // Mounted with the card, before any copy is possible.
+    expect(politeText(container)).toBe("");
+
+    enterAddress(VALID_C_ADDRESS);
+    await clickAndSettle(screen.getByRole("button", { name: "Copy C-address" }));
+
+    expect(writeText).toHaveBeenCalledWith(VALID_C_ADDRESS);
+    expect(politeText(container)).toBe("C-address copied to clipboard.");
+  });
+
+  it("announces a failed C-address copy", async () => {
+    stubClipboard("failure");
+    const { container } = render(<CexPage />);
+
+    enterAddress(VALID_C_ADDRESS);
+    await clickAndSettle(screen.getByRole("button", { name: "Copy C-address" }));
+
+    expect(politeText(container)).toBe("Copy failed. Check clipboard permissions and try again.");
+  });
+});
+
+describe("Onramp page notifications", () => {
+  const originalOpen = window.open;
+
+  afterEach(() => {
+    cleanup();
+    window.open = originalOpen;
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  /**
+   * The provider API keys are read at module scope, so the module has to be
+   * re-imported after stubbing the env to exercise the configured path.
+   */
+  const loadOnramp = async (moonpayKey: string) => {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_MOONPAY_API_KEY", moonpayKey);
+    const mod = await import("@/components/routes/onramp-page");
+    return mod.default;
+  };
+
+  const fillForm = () => {
+    const [addressInput, amountInput] = screen.getAllByRole("textbox");
+    fireEvent.change(addressInput, { target: { value: VALID_C_ADDRESS } });
+    fireEvent.change(amountInput, { target: { value: "100.00" } });
+  };
+
+  it("announces a redirect failure via an alert", async () => {
+    // No API key configured — the Continue click fails before opening a tab.
+    const OnrampPage = await loadOnramp("");
+    render(<OnrampPage />);
+    fillForm();
+
+    fireEvent.click(screen.getByRole("button", { name: /continue with moonpay/i }));
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("API key is not configured");
+  });
+
+  it("announces that a new tab was opened for checkout", async () => {
+    const open = vi.fn();
+    window.open = open as unknown as typeof window.open;
+
+    const OnrampPage = await loadOnramp("test-moonpay-key");
+    const { container } = render(<OnrampPage />);
+    fillForm();
+
+    expect(politeText(container)).toBe("");
+
+    fireEvent.click(screen.getByRole("button", { name: /continue with moonpay/i }));
+
+    expect(open).toHaveBeenCalled();
+    // The form is replaced and focus does not move, so this announcement is the
+    // only signal an AT user gets that checkout opened elsewhere.
+    expect(politeText(container)).toBe(
+      "Opened a new tab to complete your purchase with Moonpay.",
+    );
+  });
+});
+
+describe("Transaction history loading state", () => {
+  afterEach(cleanup);
+
+  it("exposes the spinner-only loading panel as a status with text", () => {
+    render(<TransactionHistory transactions={[]} loading network="TESTNET" address={ADDRESS} />);
+
+    const status = screen.getByRole("status");
+    expect(status.textContent).toContain("Loading recent transactions");
+  });
+
+  it("drops the loading status once results arrive", () => {
+    render(<TransactionHistory transactions={[]} loading={false} network="TESTNET" address={ADDRESS} />);
+
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.getByText(/No transactions found/i)).not.toBeNull();
+  });
+});

--- a/src/__tests__/stellar.test.ts
+++ b/src/__tests__/stellar.test.ts
@@ -1,6 +1,33 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Keypair, StrKey } from "@stellar/stellar-sdk";
-import { isValidStellarAddress, isCAddress, isGAddress } from "@/lib/stellar";
+import {
+  isValidStellarAddress,
+  isCAddress,
+  isGAddress,
+  isValidStellarAmount,
+  getAccountBalances,
+  clearAccountBalancesCache,
+} from "@/lib/stellar";
+
+// Horizon's network call is the only thing stubbed; every other SDK export
+// (Keypair, StrKey, ...) stays real so the address fixtures below are genuine
+// checksum-valid StrKeys rather than hand-rolled look-alikes.
+const loadAccount = vi.fn();
+
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@stellar/stellar-sdk")>();
+  return {
+    ...actual,
+    Horizon: {
+      ...actual.Horizon,
+      Server: vi.fn().mockImplementation(function MockHorizonServer(this: {
+        loadAccount: typeof loadAccount;
+      }) {
+        this.loadAccount = loadAccount;
+      }),
+    },
+  };
+});
 
 // Real, checksum-valid StrKeys derived from the SDK — not hardcoded strings
 // that merely "look" the right length/prefix. The G-address is a genuine

--- a/src/__tests__/walletProvider.test.ts
+++ b/src/__tests__/walletProvider.test.ts
@@ -1,10 +1,32 @@
-import { describe, it, expect } from "vitest";
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createElement } from "react";
+import { render, cleanup } from "@testing-library/react";
 import { useWallet } from "../components/wallet-provider";
 
+// The guard has to be reached through an actual render. Calling useWallet()
+// directly from the test body throws React's "dispatcher is null" TypeError
+// before useContext ever returns, so the assertion would pass on the wrong
+// error — or, as it did here, fail while the guard itself was fine.
+function Probe() {
+  useWallet();
+  return null;
+}
+
 describe("useWallet", () => {
-  it("throws an error when called outside of WalletProvider", () => {
-    expect(() => {
-      useWallet();
-    }).toThrow("useWallet must be used within a WalletProvider");
+  afterEach(cleanup);
+
+  it("throws an actionable error when rendered outside of WalletProvider", () => {
+    // React re-logs the render error to console.error; silence it so an
+    // expected failure doesn't read as a real one in the test output.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      expect(() => render(createElement(Probe))).toThrow(
+        "useWallet must be used within a WalletProvider"
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { ArrowRightLeft, Wallet, Send, ArrowRight, Check, AlertCircle, Loader2, ExternalLink } from "lucide-react";
 import { useWallet } from "@/components/wallet-provider";
+import LiveRegion from "@/components/live-region";
 import { isValidStellarAddress, isCAddress, isValidStellarAmount, bridgeViaContract, getExplorerUrl, getAccountBalances, getAccountMinimumBalance, formatNetworkLabel } from "@/lib/stellar";
 import type { AccountBalances } from "@/lib/stellar";
 
@@ -182,12 +183,8 @@ export default function BridgePage() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <div className="lg:col-span-2">
           <div className="card p-6">
-            <div aria-live="polite" aria-atomic="true" className="sr-only">
-              {politeAnnouncement}
-            </div>
-            <div aria-live="assertive" aria-atomic="true" className="sr-only">
-              {assertiveAnnouncement}
-            </div>
+            <LiveRegion message={politeAnnouncement} />
+            <LiveRegion politeness="assertive" message={assertiveAnnouncement} />
             {step === "form" && (
               <div className="space-y-6">
                 {isConnected && !isNetworkSupported && (

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,5 +1,18 @@
 import React, { memo } from "react";
+import Link from "next/link";
 import { Wallet } from "lucide-react";
+
+const protocolLinks = [
+  { href: "/bridge", label: "G → C Bridge" },
+  { href: "/onramp", label: "Fiat Onramp" },
+  { href: "/cex", label: "CEX Withdrawal" },
+];
+
+const resourceLinks = [
+  { href: "https://soroban.stellar.org", label: "Soroban Docs" },
+  { href: "https://github.com", label: "GitHub" },
+  { href: "https://stellar.org", label: "Stellar" },
+];
 
 const Footer = () => {
   return (
@@ -21,19 +34,41 @@ const Footer = () => {
 
           <div>
             <h3 className="text-sm font-semibold mb-3">Protocol</h3>
+            {/*
+              Internal routes go through next/link, never a bare <a>. A raw
+              anchor triggers a full document load, which tears down the client
+              tree — the wallet session in WalletProvider is in-memory only, so
+              a footer click would drop the connected address, the network
+              status and any half-filled bridge/onramp form.
+            */}
             <ul className="space-y-2">
-              <li><a href="/bridge" className="text-sm text-[var(--text-muted)] hover:text-[var(--foreground)]">G → C Bridge</a></li>
-              <li><a href="/onramp" className="text-sm text-[var(--text-muted)] hover:text-[var(--foreground)]">Fiat Onramp</a></li>
-              <li><a href="/cex" className="text-sm text-[var(--text-muted)] hover:text-[var(--foreground)]">CEX Withdrawal</a></li>
+              {protocolLinks.map((link) => (
+                <li key={link.href}>
+                  <Link href={link.href} className="text-sm text-[var(--text-muted)] hover:text-[var(--foreground)]">
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
             </ul>
           </div>
 
           <div>
             <h3 className="text-sm font-semibold mb-3">Resources</h3>
+            {/* External destinations stay plain anchors: next/link has nothing
+                to prefetch or client-navigate off-origin. */}
             <ul className="space-y-2">
-              <li><a href="https://soroban.stellar.org" target="_blank" rel="noopener noreferrer" className="text-sm text-[var(--text-muted)] hover:text-[var(--foreground)]">Soroban Docs</a></li>
-              <li><a href="https://github.com" target="_blank" rel="noopener noreferrer" className="text-sm text-[var(--text-muted)] hover:text-[var(--foreground)]">GitHub</a></li>
-              <li><a href="https://stellar.org" target="_blank" rel="noopener noreferrer" className="text-sm text-[var(--text-muted)] hover:text-[var(--foreground)]">Stellar</a></li>
+              {resourceLinks.map((link) => (
+                <li key={link.href}>
+                  <a
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-[var(--text-muted)] hover:text-[var(--foreground)]"
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              ))}
             </ul>
           </div>
         </div>

--- a/src/components/live-region.tsx
+++ b/src/components/live-region.tsx
@@ -1,0 +1,56 @@
+import React, { memo } from "react";
+
+/**
+ * LiveRegion — a visually hidden ARIA live region for screen-reader-only
+ * status notifications.
+ *
+ * The app's notifications (copy feedback, fetch errors, redirect confirmations,
+ * transaction status) are conveyed visually by swapping icons, colors and inline
+ * text. None of that reaches a screen reader on its own: the DOM change happens
+ * away from the user's cursor, so the update is silent. A live region is the
+ * mechanism that makes those changes audible.
+ *
+ * Usage rules that this component exists to enforce:
+ *
+ *  1. **Keep it mounted.** Mount the region unconditionally and pass an empty
+ *     string when there is nothing to announce. Some assistive technologies
+ *     never register a live region that is inserted into the DOM at the same
+ *     moment it receives its text, so `{condition && <LiveRegion .../>}` is
+ *     unreliable — the first announcement is the one most likely to be lost.
+ *
+ *  2. **Don't flip `politeness` on an existing region.** Several AT cache the
+ *     politeness value from when the region was first registered. When a screen
+ *     can produce both kinds of message, mount two regions and leave the
+ *     inactive one empty, so only one ever holds text.
+ *
+ * `aria-atomic="true"` makes AT re-read the whole region rather than diffing it,
+ * which keeps partial-word announcements from leaking through on text changes.
+ *
+ * @example
+ *   // One polite region, empty while idle.
+ *   <LiveRegion message={copied ? "Address copied to clipboard." : ""} />
+ *
+ * @example
+ *   // Both kinds of message: two regions, only one non-empty at a time.
+ *   <LiveRegion message={politeMessage} />
+ *   <LiveRegion politeness="assertive" message={errorMessage} />
+ */
+export interface LiveRegionProps {
+  /** Text to announce. Pass "" when there is nothing to say. */
+  message: string;
+  /**
+   * `"polite"` (default) waits for a pause in speech; `"assertive"` interrupts
+   * and should be reserved for errors and other messages the user must hear now.
+   */
+  politeness?: "polite" | "assertive";
+}
+
+function LiveRegion({ message, politeness = "polite" }: LiveRegionProps) {
+  return (
+    <div aria-live={politeness} aria-atomic="true" className="sr-only">
+      {message}
+    </div>
+  );
+}
+
+export default memo(LiveRegion);

--- a/src/components/routes/cex-page.tsx
+++ b/src/components/routes/cex-page.tsx
@@ -5,6 +5,7 @@ import { Building2, Copy, Check, ExternalLink, Wallet, X, Clock } from "lucide-r
 import { CEX_LIST } from "@/lib/types";
 import { isCAddress } from "@/lib/stellar";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import LiveRegion from "@/components/live-region";
 
 /**
  * CexPage — CEX withdrawal routing to C-addresses.
@@ -33,6 +34,15 @@ export default function CexPage() {
       : null;
 
   const withdrawalUrl = useMemo(() => selectedCex.withdrawalUrl, [selectedCex]);
+
+  // Copy feedback is icon-only (plus a visible "Copy failed" label), so the
+  // outcome has to be announced for it to exist at all for AT users.
+  const copyAnnouncement =
+    copyStatus === "copied"
+      ? "C-address copied to clipboard."
+      : copyStatus === "error"
+        ? "Copy failed. Check clipboard permissions and try again."
+        : "";
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -102,8 +112,12 @@ export default function CexPage() {
                 {addressError}
               </p>
             )}
+            {/* The invalid case is announced via role="alert"; without a
+                matching role here the *positive* result of typing a correct
+                address is silent, so an AT user gets told when they are wrong
+                but never when they are right. */}
             {addressValid && (
-              <p className="mt-2 text-xs text-green-500 flex items-center gap-1">
+              <p role="status" className="mt-2 text-xs text-green-500 flex items-center gap-1">
                 <Check className="w-3 h-3 flex-shrink-0" />
                 Valid C-address
               </p>
@@ -113,6 +127,11 @@ export default function CexPage() {
           {/* Step 3 — Withdrawal details */}
           <div className="card p-6">
             <h3 className="font-semibold mb-4">3. Withdrawal Details for {selectedCex.name}</h3>
+
+            {/* Mounted with the card, not with the copy row below (which comes
+                and goes with addressValid) — a live region inserted at the same
+                moment it gains text can go unannounced. */}
+            <LiveRegion message={copyAnnouncement} />
 
             {/* Bridge deposit address — coming soon (#299) */}
             <div className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--surface-2)] p-4 mb-4 flex items-start gap-3">
@@ -141,6 +160,8 @@ export default function CexPage() {
                   <div className="flex flex-col items-center gap-1">
                     <button
                       onClick={() => copyToClipboard(cAddress)}
+                      // Explicit name: title is not a dependable accessible name.
+                      aria-label="Copy C-address"
                       title={
                         copyStatus === "error"
                           ? "Copy failed — check clipboard permissions"

--- a/src/components/routes/dashboard-page.tsx
+++ b/src/components/routes/dashboard-page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Wallet, ArrowLeftRight, CreditCard, Building2, Copy, Check, ExternalLink, Plus, Loader2, X } from "lucide-react";
 import { useWallet } from "@/components/wallet-provider";
 import TransactionHistory from "@/components/transaction-history";
+import LiveRegion from "@/components/live-region";
 import Link from "next/link";
 import { getAccountBalances, fetchRecentTransactions, getExplorerUrl, formatNetworkLabel } from "@/lib/stellar";
 import type { BridgeTransactionData } from "@/lib/stellar";
@@ -90,6 +91,17 @@ export default function DashboardPage() {
     copyToClipboard(address);
   };
 
+  // The copy button reports its result by swapping icons (and, on failure, by
+  // adding a "Copy failed" label) — both invisible to a screen reader, which is
+  // still parked on the button and hears nothing. Announcing the outcome is the
+  // only feedback AT users get that the address reached the clipboard.
+  const copyAnnouncement =
+    copyStatus === "copied"
+      ? "Wallet address copied to clipboard."
+      : copyStatus === "error"
+        ? "Copy failed. Check clipboard permissions and try again."
+        : "";
+
   if (!isConnected) {
     return (
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
@@ -141,6 +153,12 @@ export default function DashboardPage() {
             </code>
             <button
               onClick={handleCopy}
+              // title alone is an unreliable accessible name (it is skipped by
+              // some AT and unavailable on touch), so name the button
+              // explicitly and keep title for the sighted tooltip. The name
+              // describes the action, not the result — the result is announced
+              // through the live region below.
+              aria-label="Copy wallet address"
               title={copyStatus === "error" ? "Copy failed — check clipboard permissions" : "Copy address"}
               className="p-1 rounded hover:bg-[var(--surface-2)] transition-colors"
             >
@@ -155,6 +173,7 @@ export default function DashboardPage() {
             {copyStatus === "error" && (
               <span className="text-xs text-[var(--error,#ef4444)]">Copy failed</span>
             )}
+            <LiveRegion message={copyAnnouncement} />
           </div>
           <div className="text-xs text-[var(--text-muted)] mt-1">
             <span className={isNetworkSupported ? undefined : "text-[var(--error)] font-medium"}>
@@ -261,8 +280,15 @@ export default function DashboardPage() {
         </div>
       )}
 
+      {/* The fetch error appears asynchronously (initial load or a 30s poll
+          tick), so without role="alert" it is never announced — a sighted user
+          sees the balance/activity failure, an AT user sees nothing change. The
+          unsupported-network banner above already carries the same role. */}
       {error && (
-        <div className="mb-6 p-4 rounded-lg bg-[var(--error)]/10 border border-[var(--error)]/20 text-sm text-[var(--error)]">
+        <div
+          role="alert"
+          className="mb-6 p-4 rounded-lg bg-[var(--error)]/10 border border-[var(--error)]/20 text-sm text-[var(--error)]"
+        >
           {error}
         </div>
       )}

--- a/src/components/routes/dashboard-page.tsx
+++ b/src/components/routes/dashboard-page.tsx
@@ -6,7 +6,7 @@ import { useWallet } from "@/components/wallet-provider";
 import TransactionHistory from "@/components/transaction-history";
 import Link from "next/link";
 import { getAccountBalances, fetchRecentTransactions, getExplorerUrl, formatNetworkLabel } from "@/lib/stellar";
-import type { BridgeTransactionData as BridgeTransaction } from "@/lib/stellar";
+import type { BridgeTransactionData } from "@/lib/stellar";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
 /** How often the dashboard polls for updated balances and transactions. */

--- a/src/components/routes/onramp-page.tsx
+++ b/src/components/routes/onramp-page.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import { CreditCard, Wallet, ExternalLink, ArrowRight, Check, DollarSign, AlertCircle } from "lucide-react";
 import { isValidStellarAddress, isCAddress } from "@/lib/stellar";
+import LiveRegion from "@/components/live-region";
 
 const MOONPAY_API_KEY = process.env.NEXT_PUBLIC_MOONPAY_API_KEY || "";
 const TRANSAK_API_KEY = process.env.NEXT_PUBLIC_TRANSAK_API_KEY || "";
@@ -149,6 +150,18 @@ export default function OnrampPage() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <div className="lg:col-span-2">
           <div className="card p-6">
+            {/* Pressing Continue swaps the whole form for the redirect panel and
+                opens a new tab. Focus stays where it was, so an AT user gets no
+                signal that either happened — the region announces the outcome.
+                Mounted outside the step branches so it is already registered
+                when the step flips. */}
+            <LiveRegion
+              message={
+                step === "redirect"
+                  ? `Opened a new tab to complete your purchase with ${provider?.name ?? "the provider"}.`
+                  : ""
+              }
+            />
             {step === "form" && (
               <div className="space-y-6">
                 <div>
@@ -242,8 +255,16 @@ export default function OnrampPage() {
                   </div>
                 </div>
 
+                {/* Raised by the Continue click (missing API key, or a failure
+                    while building the redirect URL) and rendered below the
+                    button the user just pressed, so nothing about it is
+                    self-evident to AT: role="alert" is what makes the failure
+                    reach the user who cannot see it. */}
                 {error && (
-                  <div className="p-4 rounded-lg bg-[var(--error)]/10 border border-[var(--error)]/20 flex items-start gap-3">
+                  <div
+                    role="alert"
+                    className="p-4 rounded-lg bg-[var(--error)]/10 border border-[var(--error)]/20 flex items-start gap-3"
+                  >
                     <AlertCircle className="w-5 h-5 text-[var(--error)] flex-shrink-0 mt-0.5" />
                     <p className="text-sm text-[var(--error)]">{error}</p>
                   </div>

--- a/src/components/transaction-history.tsx
+++ b/src/components/transaction-history.tsx
@@ -81,8 +81,13 @@ function TransactionHistory({ transactions, loading, network, address }: Props) 
         <h3 className="font-semibold">Recent Transactions</h3>
       </div>
       {loading ? (
-        <div className="p-12 flex items-center justify-center">
+        // The spinner is the only loading indicator, and lucide marks its svg
+        // aria-hidden, so this panel was an empty box to a screen reader: no
+        // announcement on entering the loading state and no text to find when
+        // navigating into it. role="status" plus a hidden label fixes both.
+        <div role="status" className="p-12 flex items-center justify-center">
           <Loader2 className="w-6 h-6 animate-spin motion-reduce:animate-none text-[var(--text-muted)]" />
+          <span className="sr-only">Loading recent transactions…</span>
         </div>
       ) : transactions.length === 0 ? (
         <div className="p-12 text-center">

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -21,13 +21,16 @@ import {
   SOROBAN_RPC_URL,
   type StellarNetwork,
   type WalletNetworkState,
+  type BridgeTransactionData,
 } from "./types";
 import { withSequenceRetry } from "./sequenceManager";
 
-export type { AppNetwork, WalletNetworkState } from "./types";
+export type { AppNetwork, WalletNetworkState, BridgeTransactionData } from "./types";
+
+/** Seconds a built transaction stays valid before the network rejects it. */
+const TRANSACTION_TIMEOUT_SECONDS = 30;
 
 export async function getHorizonServer(network: StellarNetwork): Promise<Horizon.Server> {
-  const { Horizon } = await import("@stellar/stellar-sdk");
   return new Horizon.Server(HORIZON_URL[network]);
 }
 
@@ -38,12 +41,10 @@ export async function getSorobanRpcServer(network: StellarNetwork): Promise<rpc.
       `No Soroban RPC URL configured for ${network}. Set NEXT_PUBLIC_SOROBAN_RPC_URL_${network} in your environment.`
     );
   }
-  const { rpc } = await import("@stellar/stellar-sdk");
   return new rpc.Server(url);
 }
 
 export async function getNetworkPassphrase(network: StellarNetwork): Promise<string> {
-  const { Networks } = await import("@stellar/stellar-sdk");
   return network === "PUBLIC" ? Networks.PUBLIC : Networks.TESTNET;
 }
 
@@ -388,8 +389,6 @@ async function buildSignAndSubmit(
   passphrase: string,
   onPhase?: (phase: "signing" | "submitting") => void
 ): Promise<PaymentResult> {
-  const { TransactionBuilder, Operation } = await import("@stellar/stellar-sdk");
-
   // Fetch a dynamic fee bid (2× base fee, capped at 10 000 stroops) so the
   // transaction is not rejected during surge-pricing windows. (#301)
   const fee = await getRecommendedFee(network);
@@ -483,8 +482,6 @@ async function resolveAsset(
   sourceAddress: string,
   assetCode: string
 ): Promise<Asset> {
-  const { Asset } = await import("@stellar/stellar-sdk");
-
   if (assetCode === "XLM") {
     return Asset.native();
   }
@@ -559,7 +556,10 @@ export async function bridgeViaContract(
     );
   }
 
-  return buildAndSubmitPayment(sourceAddress, cAddress, amount, assetCode, network);
+  // Forward onPhase so the caller's "Signing..."/"Submitting..." states still
+  // fire on this path; without it the UI sits on "Signing..." until the
+  // transaction resolves.
+  return buildAndSubmitPayment(sourceAddress, cAddress, amount, assetCode, network, onPhase);
 }
 
 export function getExplorerUrl(


### PR DESCRIPTION
## Summary

The footer is rendered by the root layout on **every** page, but its Protocol links navigated with bare `<a href="/bridge">` anchors instead of `next/link`. A raw same-origin anchor is a full document load, so every footer click threw away the client tree — including the wallet session, which `WalletProvider` holds in memory only.

This PR routes the footer's internal destinations through `next/link` and adds a regression test that fails if any same-origin anchor bypasses the App Router again.

## Linked Issue

Closes #331

## Changes

**The bug.** [`src/components/footer.tsx`](https://github.com/lemarjohnny781/C-Address-Onboarding-Bridge--Frontend-/blob/fix/footer-client-side-routing/src/components/footer.tsx) was the only place in the app that navigated internally without the router:

```diff
- <li><a href="/bridge" className="...">G → C Bridge</a></li>
- <li><a href="/onramp" className="...">Fiat Onramp</a></li>
- <li><a href="/cex"    className="...">CEX Withdrawal</a></li>
```

Everywhere else already uses `next/link` or the `PrefetchLink` wrapper — `navbar.tsx:131` and `:261`, `app/page.tsx:78`, `routes/dashboard-page.tsx:135`. The footer was the lone exception, and because the root layout renders it on all six routes, it was reachable from every page in the app.

**Why it matters.** Three concrete consequences, in severity order:

1. **The wallet session is destroyed.** `wallet-provider.tsx:42-61` keeps `address`, `network`, `networkStatus`, `walletNetworkName` and `networkMismatch` in `useState`, with no `localStorage`/`sessionStorage` persistence anywhere in the file. A full reload resets all of it, so a user who clicked "Fiat Onramp" in the footer landed on `/onramp` disconnected and had to reconnect Freighter. The dismissed network-mismatch warning also reappears.
2. **In-progress form state is discarded.** A half-filled bridge form (`toAddress`, `amount`, `asset`, and the `step` the user had reached) or onramp form is gone with no warning.
3. **The prefetch is wasted.** `PrefetchLink` in the navbar warms all four routes via `router.prefetch()` as soon as the navbar enters view — which is immediately, since it is `fixed` at the top. A raw anchor ignores that entirely and re-downloads the JS bundle.

**The fix.** Internal routes now render through `next/link`; both link lists moved to module-level arrays, matching the existing `navLinks` pattern in the navbar. External resource links deliberately stay plain `<a>` with `target="_blank"` and `rel="noopener noreferrer"` — `next/link` has nothing to prefetch or client-navigate off-origin. Both choices are commented in place so the asymmetry doesn't read as an oversight later.

**The test.** New `src/__tests__/footer-routing.test.tsx`, 4 tests. The key detail: it stubs `next/link` with a `data-next-link` marker attribute, because a rendered `Link` and a raw `<a>` are **indistinguishable in the DOM** — that is precisely why this regressed unnoticed and why a naive `getByRole("link")` assertion would not have caught it. Coverage:

- every internal route (`/bridge`, `/onramp`, `/cex`) is rendered through `next/link`;
- no `a[href^="/"]` anywhere in the footer bypasses the router (this is the assertion that catches a *newly added* raw anchor, not just the three known ones);
- external anchors keep `target="_blank"` plus `noopener`/`noreferrer`;
- the visible labels still point at the right hrefs.

Verified the test genuinely detects the bug: against the pre-fix footer it fails 2 of 4 with `/bridge must use next/link, not a raw <a>`; against the fix, 4/4 pass.

## Testing

- [x] `npm run lint` passes — 0 errors. 3 warnings, all pre-existing and untouched by this PR (`app/page.tsx` unused `Link`, `onramp-page.tsx` unused `useMemo`, `sequenceManager.ts` unused `Account`).
- [x] `npm run typecheck` passes — clean.
- [x] `npm run test` passes — 189/189 across 19 files.
- [x] `npm run build` passes — all 6 routes prerender static (`/`, `/_not-found`, `/bridge`, `/cex`, `/dashboard`, `/onramp`). The asset-size warning on the 960 KiB Stellar SDK chunk is pre-existing and unrelated.

One local-environment caveat, no action needed for CI: `npm test` cannot run on Node 20, because Node 20 rejects `--no-experimental-webstorage` inside `NODE_OPTIONS` (exit code 9 before any test executes), which also fails the husky pre-commit hook. CI pins Node 22, where the flag is accepted — so this is a local-only papercut, and the suite was verified with `npx vitest run`. Worth moving the flag into vitest's `poolOptions.forks.execArgv` in a separate PR so contributors on Node 20 aren't blocked.

## A note on the commit range

This branch carries two commits that predate the routing work and are **not** part of this fix:

- `83fa489` `fix: repair broken main — restore definitions dropped in refactor merge`
- `c6c6add` `a11y: announce notification state changes to screen readers`

They are included because `main` currently does not build — the merges of #313 and #314 kept call sites but dropped definitions, leaving 57 typecheck errors, a live `ReferenceError` on `TRANSACTION_TIMEOUT_SECONDS` in the core transaction path, and no `@testing-library/react` in `package.json` (which the new test needs). Rebasing this fix onto `main` alone would produce a red PR for reasons unrelated to routing.

**The routing change itself is exactly one commit — `e2e41b5`, 2 files.** Review that commit in isolation for a focused diff. If you would rather land the repair separately, say so and this can be restacked onto a PR for `83fa489` instead.

## Screenshots

No visual change — the footer renders identically. The difference is behavioral: footer navigation no longer reloads the document, so the wallet stays connected across a footer click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
