### PR TITLE
fix(i18n): format transaction dates against the app's declared locale

### DIFF
--- a/src/__tests__/localization.test.ts
+++ b/src/__tests__/localization.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { APP_LOCALE, EMPTY_VALUE, formatTransactionDate } from "@/lib/format";
+
+/** A fixed instant: 14 March 2026, 15:04 UTC. */
+const TIMESTAMP = Date.UTC(2026, 2, 14, 15, 4, 0);
+
+describe("formatTransactionDate", () => {
+  it("formats a timestamp using the app locale, not the host locale", () => {
+    // en-US renders month-first with no zero padding. Asserting the exact
+    // string is only safe because the locale is pinned in lib/format.ts — this
+    // assertion is what would break if a call site went back to the ambient
+    // locale.
+    expect(formatTransactionDate(TIMESTAMP)).toBe("3/14/2026");
+  });
+
+  it("is unaffected by the ambient locale of the process", () => {
+    // Intl honours LANG/LC_ALL only at startup, so this asserts the property
+    // that matters directly: the output must equal an explicit en-US format
+    // and must differ from what a European locale would produce.
+    const explicit = new Date(TIMESTAMP).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "numeric",
+      day: "numeric",
+    });
+    expect(formatTransactionDate(TIMESTAMP)).toBe(explicit);
+    expect(formatTransactionDate(TIMESTAMP)).not.toBe(
+      new Date(TIMESTAMP).toLocaleDateString("de-DE")
+    );
+  });
+
+  it("returns the same string on repeated calls (stable across renders)", () => {
+    expect(formatTransactionDate(TIMESTAMP)).toBe(formatTransactionDate(TIMESTAMP));
+  });
+
+  it("collapses a NaN timestamp to the empty placeholder instead of 'Invalid Date'", () => {
+    // lib/stellar.ts produces NaN when Horizon returns a malformed created_at.
+    expect(formatTransactionDate(NaN)).toBe(EMPTY_VALUE);
+    expect(formatTransactionDate(NaN)).not.toContain("Invalid");
+  });
+
+  it("collapses non-finite timestamps to the empty placeholder", () => {
+    expect(formatTransactionDate(Infinity)).toBe(EMPTY_VALUE);
+    expect(formatTransactionDate(-Infinity)).toBe(EMPTY_VALUE);
+  });
+
+  it("formats the unix epoch rather than treating 0 as missing", () => {
+    // 0 is falsy but a legitimate instant; a truthiness guard would wrongly
+    // blank it out.
+    expect(formatTransactionDate(0)).not.toBe(EMPTY_VALUE);
+  });
+});
+
+describe("locale declaration", () => {
+  const read = (relative: string) =>
+    fs.readFileSync(path.resolve(__dirname, relative), "utf-8");
+
+  it("APP_LOCALE agrees with the lang attribute on <html>", () => {
+    const layout = read("../app/layout.tsx");
+    const lang = layout.match(/<html\s+lang="([^"]+)"/)?.[1];
+
+    expect(lang).toBeDefined();
+    // "en-US" must remain a specialisation of the declared "en".
+    expect(APP_LOCALE.split("-")[0]).toBe(lang!.split("-")[0]);
+  });
+
+  it("no component formats dates with an implicit locale", () => {
+    // Guards the regression this module exists to prevent: a bare
+    // toLocaleDateString()/toLocaleTimeString()/toLocaleString() call inherits
+    // the host locale and desynchronises server and client output.
+    const componentDir = path.resolve(__dirname, "../components");
+    const appDir = path.resolve(__dirname, "../app");
+
+    const walk = (dir: string): string[] =>
+      fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) return walk(full);
+        return /\.tsx?$/.test(entry.name) ? [full] : [];
+      });
+
+    const offenders = [...walk(componentDir), ...walk(appDir)].filter((file) =>
+      /toLocale(?:Date|Time)?String\(\s*\)/.test(fs.readFileSync(file, "utf-8"))
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/components/transaction-history.tsx
+++ b/src/components/transaction-history.tsx
@@ -2,6 +2,7 @@ import React, { memo, useMemo } from "react";
 import { ArrowLeftRight, CreditCard, Building2, ExternalLink, Loader2 } from "lucide-react";
 import type { BridgeTransactionData } from "@/lib/types";
 import { getExplorerUrl } from "@/lib/stellar";
+import { formatTransactionDate } from "@/lib/format";
 import type { StellarNetwork } from "@/lib/types";
 
 const typeConfig: Record<string, { icon: typeof ArrowLeftRight; label: string; color: string }> = {
@@ -29,7 +30,10 @@ const TransactionItem = memo(function TransactionItem({ tx, network }: { tx: Bri
   const status = statusConfig[tx.status];
   const Icon = type.icon;
 
-  const date = useMemo(() => new Date(tx.timestamp).toLocaleDateString(), [tx.timestamp]);
+  // Formatted against the app's declared locale rather than the host's, so the
+  // date matches the surrounding English text on every machine and renders the
+  // same on the server as it does after hydration.
+  const date = useMemo(() => formatTransactionDate(tx.timestamp), [tx.timestamp]);
   const toShort = useMemo(() => {
     if (!tx.toAddress) return "";
     return tx.toAddress.length > 20 ? `${tx.toAddress.slice(0, 10)}...${tx.toAddress.slice(-6)}` : tx.toAddress;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,49 @@
+/**
+ * Locale-sensitive display formatting.
+ *
+ * The app ships a single language: every UI string is an English literal and
+ * the document declares `<html lang="en">` in app/layout.tsx. Formatting must
+ * agree with that declaration, so this module pins an explicit locale instead
+ * of letting each call site inherit the ambient runtime locale.
+ *
+ * Two things go wrong when `toLocaleDateString()` is called with no locale:
+ *
+ *   - It resolves to the *host's* locale, so the same transaction reads
+ *     "3/14/2026" on one machine and "14.03.2026" on another while the text
+ *     around it stays English. Under SSR it resolves to the server's locale
+ *     and then to the browser's on hydration, which React reports as a text
+ *     mismatch.
+ *   - It makes rendered output untestable: an assertion that passes in CI
+ *     (en-US) fails for a contributor whose machine is set to de-DE.
+ *
+ * When real multi-language support arrives, APP_LOCALE becomes the negotiated
+ * request locale and these helpers take it as a parameter; call sites don't
+ * change.
+ */
+
+/** Display locale for the app. Keep in sync with `<html lang>` in app/layout.tsx. */
+export const APP_LOCALE = "en-US";
+
+/** Shown in place of a date/amount that cannot be formatted. */
+export const EMPTY_VALUE = "—";
+
+/**
+ * Formats a transaction timestamp as a short calendar date.
+ *
+ * Timestamps reach the UI via `new Date(p.created_at || Date.now()).getTime()`
+ * in lib/stellar.ts, which yields NaN for a malformed Horizon `created_at`.
+ * Formatting that directly renders the literal string "Invalid Date" into the
+ * transaction list, so unusable input collapses to EMPTY_VALUE instead.
+ */
+export function formatTransactionDate(timestamp: number): string {
+  if (!Number.isFinite(timestamp)) return EMPTY_VALUE;
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return EMPTY_VALUE;
+
+  return date.toLocaleDateString(APP_LOCALE, {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+  });
+}


### PR DESCRIPTION
## Problem

`transaction-history.tsx` formatted transaction dates with `toLocaleDateString()` and **no locale argument**, which resolves to the host machine's locale. Three problems follow from that:

**1. The rendered date contradicts the document's own language declaration.** Every UI string in this app is an English literal and `app/layout.tsx` declares `<html lang="en">`. With an implicit locale the same transaction reads `3/14/2026` on one machine and `14.03.2026` on another, next to unchanged English labels.

**2. Latent hydration mismatch.** Under SSR the server resolves *its* locale and the browser resolves the *user's*, which React reports as a text mismatch. This does not fire today only because transactions are fetched client-side after wallet connect (`dashboard-page.tsx`), so the list is empty during SSR. The bug is armed, not absent — it lands as soon as this list renders on the server.

**3. The literal string `"Invalid Date"` could reach users.** `lib/stellar.ts` derives timestamps via `new Date(p.created_at || Date.now()).getTime()`, which yields `NaN` for a malformed Horizon `created_at`. That formatted straight into the transaction list.

## Change

Adds `src/lib/format.ts`, which pins `APP_LOCALE = "en-US"` and exposes `formatTransactionDate()`. Non-finite timestamps collapse to the `—` placeholder the dashboard already uses for absent values.

The module is deliberately shaped so that if real multi-language support ever arrives, `APP_LOCALE` becomes the negotiated request locale and the call sites do not change.

## Tests

`src/__tests__/localization.test.ts`, 8 cases:

- Pinned-locale output, and independence from the ambient process locale
- Stability across repeated calls
- `NaN` / `±Infinity` → placeholder, never the string `"Invalid Date"`
- Epoch `0` is formatted, not treated as missing — a truthiness guard would wrongly blank it
- `APP_LOCALE` agrees with the `lang` attribute on `<html>`
- A regression guard that walks `src/components` and `src/app` and fails if any file reintroduces a bare `toLocale*String()` call

## Scope

No i18n framework is introduced. There is no localization layer in this repo at all, and adding message catalogs plus locale routing is an architectural change rather than this fix.

Balance and amount formatting still uses `.toFixed(2)` in `bridge/page.tsx`, `dashboard-page.tsx` and `onramp-page.tsx`. Routing those through `Intl.NumberFormat` would add grouping separators and change how financial figures render, which is a design decision and not made here.

## Verification, and a note on the base

This branch is based on `main`, which is **currently broken independently of this change**: 56 `tsc --noEmit` errors and 5 failing test files. #427 is the fix for that and is open, clean and mergeable.

Measured with and without this commit applied:

| Check | Clean `main` | With this change |
|---|---|---|
| `tsc --noEmit` | 56 errors | 56 errors |
| `vitest run` | 5 files failing | 5 files failing |

Identical, and no error or failure references the touched files. `localization.test.ts` passes standalone, 8/8.

Separately, `npm run build` with `ENFORCE_BUDGET=true` (what the CI workflow sets) fails on the 100 KiB entrypoint budget at ~989–1000 KiB, caused by the 960 KiB Stellar SDK chunk. Confirmed pre-existing on clean `main` and unaffected by this change; it needs the SDK lazy-loaded out of the initial bundle, which #427 also documents as not addressed.

**Reviewing this on its own:** merging #427 first is recommended, otherwise the full suite and typecheck fail here for reasons that predate this branch. The three files in this diff can be reviewed independently in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
