### PR TITLE
fix: add missing imports in bridge, cex, and dashboard pages

### DIFF
--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -75,4 +75,32 @@ describe("wallet session persistence (#343)", () => {
     expect(isSessionExpired(session, NOW + SESSION_TTL_MS + 1)).toBe(true);
     expect(isSessionExpired({ ...session, updatedAt: NaN }, NOW)).toBe(true);
   });
+
+  it("markDisconnected returns the written session", () => {
+    const result = markDisconnected(ADDRESS, NOW);
+    expect(result.manuallyDisconnected).toBe(true);
+    expect(result.address).toBe(ADDRESS);
+    expect(result.updatedAt).toBe(NOW);
+  });
+
+  it("markConnected returns the written session", () => {
+    const result = markConnected(ADDRESS, NOW);
+    expect(result.manuallyDisconnected).toBe(false);
+    expect(result.address).toBe(ADDRESS);
+    expect(result.updatedAt).toBe(NOW);
+  });
+
+  it("markDisconnected with no address defaults to null", () => {
+    const result = markDisconnected(undefined, NOW);
+    expect(result.address).toBeNull();
+    expect(result.manuallyDisconnected).toBe(true);
+  });
+
+  it("markConnected with null address clears the disconnect flag", () => {
+    markDisconnected(ADDRESS, NOW);
+    markConnected(null, NOW + 1000);
+    const session = loadSession(NOW + 2000);
+    expect(session.manuallyDisconnected).toBe(false);
+    expect(session.address).toBeNull();
+  });
 });

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { ArrowRightLeft, Wallet, Send, ArrowRight, Check, AlertCircle, Loader2, ExternalLink } from "lucide-react";
 import { useWallet } from "@/components/wallet-provider";
-import { isValidStellarAddress, isCAddress, isValidStellarAmount, bridgeViaContract, getExplorerUrl, getAccountBalances, getAccountMinimumBalance, formatNetworkLabel, getEstimatedFeeXLM } from "@/lib/stellar";
+import { isValidStellarAddress, isCAddress, isValidStellarAmount, bridgeViaContract, getExplorerUrl, getAccountBalances, getAccountMinimumBalance, formatNetworkLabel, getEstimatedFeeXLM, toSafeErrorMessage } from "@/lib/stellar";
 import type { AccountBalances } from "@/lib/stellar";
 import { useDebounce } from "@/hooks/useDebounce";
+import LiveRegion from "@/components/live-region";
 
 type Step = "form" | "review" | "confirm";
 type TxStatus = "idle" | "signing" | "submitting" | "success" | "error";

--- a/src/components/routes/cex-page.tsx
+++ b/src/components/routes/cex-page.tsx
@@ -5,6 +5,7 @@ import { Building2, Copy, Check, ExternalLink, Wallet, X, Clock } from "lucide-r
 import { CEX_LIST, type CexConfig } from "@/lib/types";
 import { isCAddress } from "@/lib/stellar";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { useDebounce } from "@/hooks/useDebounce";
 import LiveRegion from "@/components/live-region";
 
 /**

--- a/src/components/routes/dashboard-page.tsx
+++ b/src/components/routes/dashboard-page.tsx
@@ -7,7 +7,7 @@ import AvatarUpload from "@/components/avatar-upload";
 import TransactionHistory from "@/components/transaction-history";
 import LiveRegion from "@/components/live-region";
 import Link from "next/link";
-import { getAccountBalances, fetchRecentTransactions, getExplorerUrl, formatNetworkLabel } from "@/lib/stellar";
+import { getAccountBalances, fetchRecentTransactions, getExplorerUrl, formatNetworkLabel, toSafeErrorMessage } from "@/lib/stellar";
 import type { BridgeTransactionData } from "@/lib/stellar";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 


### PR DESCRIPTION
Closes #374

---

## Summary

Three components were referencing identifiers that were never imported, causing runtime `ReferenceError` crashes and TypeScript build failures.

## Changes

| File | Problem | Fix |
|---|---|---|
| `src/app/bridge/page.tsx` | `LiveRegion` JSX and `toSafeErrorMessage()` used but not imported | Added `LiveRegion` import from `@/components/live-region`; added `toSafeErrorMessage` to the existing `@/lib/stellar` import |
| `src/components/routes/cex-page.tsx` | `useDebounce()` called on every keystroke but never imported — component threw `ReferenceError` on first render | Added `useDebounce` import from `@/hooks/useDebounce` |
| `src/components/routes/dashboard-page.tsx` | `toSafeErrorMessage()` called in the fetch error handler but missing from the `@/lib/stellar` import | Added `toSafeErrorMessage` to the existing import |

Also adds four targeted unit tests to `src/__tests__/session.test.ts` covering return values of `markConnected`/`markDisconnected` and the `null`-address paths that were exercised in production but not previously verified.

## Testing

- All existing tests continue to pass.
- New session unit tests cover the previously untested return-value and null-address paths.
- TypeScript errors for all three files are resolved.
