### PR TITLE
fix: implement avatar storage key

### DIFF
--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -60,7 +60,7 @@ export function isRenderableAvatar(value: unknown): value is string {
 
 /** Storage key for an address. Exported so tests and docs can reference it. */
 export function avatarStorageKey(address: string): string {
-  throw new Error('Not implemented: avatarStorageKey');
+  return `${STORAGE_PREFIX}${address}`;
 }
 
 function storage(): Storage | null {


### PR DESCRIPTION
## Summary

Implements `avatarStorageKey` so avatar data is stored under the documented per-address key format.

## Linked Issue

Closes #504

## Changes

- Return the existing `avatar:` storage prefix combined with the provided address.
- - Keep the public function signature and doc comment unchanged.
## Testing

- Attempted `npm test -- -t 'avatarStorageKey'`; the repository script requires Node >=20 and fails under the system Node 18 because `NODE_OPTIONS=--no-experimental-webstorage` is rejected.
- - Re-ran Vitest through temporary Node 20. The broad name filter imports unrelated seeded exercises and fails on pre-existing unrelated errors (`onramp-page.tsx` duplicate `LiveRegion`, `getTranslations` stub).
- - Ran `src/__tests__/avatar.test.ts -t 'avatar storage'` through Node 20; it reaches the avatar storage tests but is blocked by other intentionally stubbed avatar helpers (`saveAvatar`, `loadAvatar`), unrelated to this function.
- - Verified the diff is limited to `src/lib/avatar.ts` and only replaces the `avatarStorageKey` stub body.