### PR TITLE
feat: recent activity feed on the landing page

### DIFF
--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { truncateAddress, type FundingActivityEvent } from "@/lib/activityFeed";
+
+/**
+ * Proxies the indexer's public funding-event API for the landing page feed
+ * (#489). Kept server-side (rather than having the browser call the indexer
+ * directly) so the indexer's base URL/credentials are never in client JS,
+ * and so every address is truncated here — before the response ever leaves
+ * the server — instead of relying on the client to redact it.
+ *
+ * Always resolves with a 200 and an array (possibly empty): an unreachable
+ * or misconfigured indexer is treated as "no recent activity", not an error
+ * the landing page needs to surface.
+ */
+export async function GET() {
+  const indexerUrl = process.env.INDEXER_EVENTS_URL;
+  if (!indexerUrl) {
+    return NextResponse.json([], { headers: { "Cache-Control": "no-store" } });
+  }
+
+  try {
+    const res = await fetch(`${indexerUrl}?type=funding&limit=20`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) throw new Error(`Indexer returned ${res.status}`);
+
+    const data: unknown = await res.json();
+    if (!Array.isArray(data)) throw new Error("Indexer returned an unexpected shape");
+
+    const events: FundingActivityEvent[] = data
+      .filter(
+        (e): e is { id: string; toAddress: string; amount: string; asset: string; timestamp: number } =>
+          typeof e === "object" &&
+          e !== null &&
+          typeof (e as Record<string, unknown>).toAddress === "string" &&
+          typeof (e as Record<string, unknown>).amount === "string"
+      )
+      .map((e) => ({
+        id: e.id,
+        address: truncateAddress(e.toAddress),
+        amount: e.amount,
+        asset: e.asset,
+        timestamp: e.timestamp,
+      }));
+
+    return NextResponse.json(events, { headers: { "Cache-Control": "no-store" } });
+  } catch {
+    return NextResponse.json([], { headers: { "Cache-Control": "no-store" } });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight, Shield, Zap, CreditCard, Building2, Globe, Code } from "lucide-react";
 import { PrefetchLink } from "@/components/prefetch-link";
+import { RecentActivityFeed } from "@/components/RecentActivityFeed";
 
 const features = [
   {
@@ -150,6 +151,8 @@ export default function LandingPage() {
           </div>
         </div>
       </section>
+
+      <RecentActivityFeed />
 
       <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
         <div className="relative p-12 rounded-2xl border border-[var(--border)] bg-gradient-to-br from-[var(--primary)]/5 via-[var(--secondary)]/5 to-transparent overflow-hidden text-center">

--- a/src/components/RecentActivityFeed.tsx
+++ b/src/components/RecentActivityFeed.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Activity } from "lucide-react";
+import { fetchRecentActivity, type FundingActivityEvent } from "@/lib/activityFeed";
+
+const POLL_INTERVAL_MS = 15_000;
+
+function formatRelativeTime(timestamp: number): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+/**
+ * Anonymised live activity feed for the landing page (#489). Shows that the
+ * bridge is actually being used — recent funding events with amounts and
+ * truncated addresses only — without exposing anything that could identify
+ * a user. Polls `/api/activity` periodically, pausing while the tab is
+ * hidden so a backgrounded tab doesn't keep polling for nothing.
+ */
+export function RecentActivityFeed() {
+  const [events, setEvents] = useState<FundingActivityEvent[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      const data = await fetchRecentActivity();
+      if (!cancelled) {
+        setEvents(data);
+        setLoaded(true);
+      }
+    };
+
+    const startPolling = () => {
+      if (intervalRef.current) return;
+      load();
+      intervalRef.current = setInterval(load, POLL_INTERVAL_MS);
+    };
+
+    const stopPolling = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        startPolling();
+      }
+    };
+
+    if (!document.hidden) startPolling();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      stopPolling();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
+
+  return (
+    <section
+      className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-24"
+      aria-label="Recent bridge activity"
+    >
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Activity className="w-4 h-4 text-[var(--primary-light)]" />
+          <h2 className="font-semibold">Recent Activity</h2>
+        </div>
+
+        {!loaded ? (
+          <p className="text-sm text-[var(--text-muted)]" data-testid="activity-loading">
+            Loading recent activity…
+          </p>
+        ) : events.length === 0 ? (
+          <p className="text-sm text-[var(--text-muted)]" data-testid="activity-empty">
+            No funding activity in the last little while — check back soon.
+          </p>
+        ) : (
+          <ul className="space-y-3" data-testid="activity-list">
+            {events.map((event) => (
+              <li
+                key={event.id}
+                className="flex items-center justify-between text-sm"
+                data-testid="activity-item"
+              >
+                <span className="font-mono text-[var(--text-muted)]">{event.address}</span>
+                <span className="font-medium">
+                  {event.amount} {event.asset}
+                </span>
+                <span className="text-[var(--text-muted)]">{formatRelativeTime(event.timestamp)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default RecentActivityFeed;

--- a/src/components/__tests__/RecentActivityFeed.test.tsx
+++ b/src/components/__tests__/RecentActivityFeed.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { RecentActivityFeed } from '../RecentActivityFeed';
+import { truncateAddress } from '@/lib/activityFeed';
+
+const originalFetch = global.fetch;
+
+describe('RecentActivityFeed (#489)', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('shows a meaningful empty state when there is no recent activity', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    render(<RecentActivityFeed />);
+    await waitFor(() => expect(screen.getByTestId('activity-empty')).toBeInTheDocument());
+    expect(screen.getByTestId('activity-empty')).toHaveTextContent(/no funding activity/i);
+  });
+
+  it('shows a meaningful empty state when the source is unreachable', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+    render(<RecentActivityFeed />);
+    await waitFor(() => expect(screen.getByTestId('activity-empty')).toBeInTheDocument());
+  });
+
+  it('renders only truncated addresses, never a full one', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: '1',
+          address: 'GAAAAAAA…WHF9',
+          amount: '100',
+          asset: 'USDC',
+          timestamp: Date.now(),
+        },
+      ],
+    });
+    render(<RecentActivityFeed />);
+    const item = await screen.findByTestId('activity-item');
+    expect(item).toHaveTextContent('GAAAAAAA…WHF9');
+    expect(item.textContent).not.toMatch(/G[A-Z2-7]{50,}/);
+  });
+});
+
+describe('truncateAddress', () => {
+  it('truncates a long address to first 8 and last 4 characters', () => {
+    const full = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    expect(truncateAddress(full)).toBe('GAAAAAAA…AWHF');
+  });
+
+  it('leaves a short value unchanged', () => {
+    expect(truncateAddress('short')).toBe('short');
+  });
+});

--- a/src/lib/activityFeed.ts
+++ b/src/lib/activityFeed.ts
@@ -1,0 +1,45 @@
+/**
+ * Anonymised funding-event feed for the landing page (#489).
+ *
+ * Only an amount, an asset code, a truncated destination address and a
+ * timestamp are ever carried — no full address, no source/from address, and
+ * no memo or transaction hash. A full address or a from/to pair would let a
+ * visitor correlate an entry back to a specific account; truncating to
+ * "GABCD…WXYZ" and dropping the source keeps the feed illustrative without
+ * being identifying.
+ */
+export interface FundingActivityEvent {
+  id: string;
+  /** Already truncated server-side — see truncateAddress. */
+  address: string;
+  amount: string;
+  asset: string;
+  timestamp: number;
+}
+
+/** Shortens an address for display: GABCDEFG…WXYZ. Never send the full value to the client. */
+export function truncateAddress(address: string): string {
+  return address.length > 12
+    ? `${address.slice(0, 8)}…${address.slice(-4)}`
+    : address;
+}
+
+const ACTIVITY_ENDPOINT = '/api/activity';
+
+/**
+ * Fetches recent funding events for display. Sourced from our own `/api/activity`
+ * route, which itself proxies the indexer's public event API server-side (so the
+ * indexer URL and any auth are never exposed to the browser). Never throws —
+ * callers should treat a failure the same as "no recent activity" and show the
+ * empty state rather than an error.
+ */
+export async function fetchRecentActivity(): Promise<FundingActivityEvent[]> {
+  try {
+    const res = await fetch(ACTIVITY_ENDPOINT, { cache: 'no-store' });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data) ? (data as FundingActivityEvent[]) : [];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
Adds an anonymised, live "Recent Activity" section to the landing page (`src/app/page.tsx`) so a visitor deciding whether to trust the bridge with funds can see it is actually being used.

- New `RecentActivityFeed` component polls a new `/api/activity` route every 15s, pausing while the tab is hidden (`document.visibilitychange`) so a backgrounded tab doesn't keep polling.
- `/api/activity` is a server route that proxies the indexer's public event API (`INDEXER_EVENTS_URL` server-only env var) — the indexer's URL/credentials never reach the browser, and every address is truncated **server-side** before the response leaves the server.
- Each feed entry carries only an amount, asset, truncated destination address (`GABCD…WXYZ`), and timestamp — no full address, no source/from address, no memo or tx hash — so nothing in the feed can be correlated back to an individual user.
- A meaningful empty state ("No funding activity in the last little while — check back soon.") renders when there's nothing recent or the indexer is unreachable, instead of an error or a blank section.

## Context / behavior
- Before: the landing page only described the product with no evidence it's live.
- After: a "Recent Activity" panel sits above the closing CTA, showing recent funding events or the empty state.
- No indexer is wired up in this environment yet, so `INDEXER_EVENTS_URL` is unset by default and the route returns `[]` — the UI correctly falls back to the empty state in that case (covered by tests).

## Testing
- Added `src/components/__tests__/RecentActivityFeed.test.tsx`: empty state (no data), empty state (fetch failure), and that only truncated addresses ever render (asserts against a full-address regex).
- Added truncation unit tests for `truncateAddress` in the same file.
- **Not run in this environment**: `npm run lint`, `npm run typecheck`, `npm run test`, `npm run build` — dependencies were not installed per the task constraints (no `npm ci`). Please run the full CI suite before merge.

Closes #489