### PR TITLE
feat: feature flag panel wired to a real backend

### DIFF
--- a/src/app/api/feature-flags/route.ts
+++ b/src/app/api/feature-flags/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { FEATURE_FLAGS } from "@/lib/featureFlags";
+
+/**
+ * Serves feature flag definitions from the server rather than the client
+ * bundle (#490). Today this returns the same definitions that used to be
+ * hardcoded on the client, but because it's a server endpoint the values it
+ * returns can change — from an admin tool, a database, a config service —
+ * without a client redeploy, which is the entire point of having flags.
+ *
+ * No-store: flag state must never be served from an intermediary cache, or a
+ * flag flipped off in an incident would keep looking "on" to some clients.
+ */
+export async function GET() {
+  return NextResponse.json(FEATURE_FLAGS, {
+    headers: { "Cache-Control": "no-store" },
+  });
+}

--- a/src/components/FeatureFlagPanel.tsx
+++ b/src/components/FeatureFlagPanel.tsx
@@ -70,7 +70,17 @@ export function FeatureFlagPanel() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen]);
 
-  if (process.env.NODE_ENV !== "development") return null;
+  // Restricted to development, or to an explicitly authorised operator in
+  // production: NEXT_PUBLIC_FLAG_PANEL_TOKEN must be set and match a token
+  // the operator has stored in this browser's localStorage. Flags can
+  // control in-development or sensitive features, so the panel to flip them
+  // is not shipped open to every visitor. (#490)
+  const isAuthorisedInProd =
+    typeof window !== "undefined" &&
+    !!process.env.NEXT_PUBLIC_FLAG_PANEL_TOKEN &&
+    window.localStorage.getItem("ff_panel_token") === process.env.NEXT_PUBLIC_FLAG_PANEL_TOKEN;
+
+  if (process.env.NODE_ENV !== "development" && !isAuthorisedInProd) return null;
 
 
   return (

--- a/src/contexts/FeatureFlagContext.tsx
+++ b/src/contexts/FeatureFlagContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { createContext, useContext, useState, type ReactNode } from 'react';
-import { FEATURE_FLAGS, isFeatureEnabled, getDevOverrides, setDevOverride, clearDevOverride } from '@/lib/featureFlags';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { FEATURE_FLAGS, isFeatureEnabled, getDevOverrides, setDevOverride, clearDevOverride, fetchRemoteFlags } from '@/lib/featureFlags';
 
 interface FeatureFlagContextValue {
   isEnabled: (key: string) => boolean;
@@ -17,6 +17,19 @@ export function FeatureFlagProvider({ children }: { children: ReactNode }) {
   const [devOverrides, setDevOverrides] = useState<Record<string, boolean>>(
     typeof window !== 'undefined' ? getDevOverrides() : {}
   );
+  // Bumped after the remote fetch resolves so consumers re-render with the
+  // served definitions instead of being stuck on the bundled defaults.
+  const [, setRemoteVersion] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchRemoteFlags().then(() => {
+      if (!cancelled) setRemoteVersion((v) => v + 1);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const isEnabled = (key: string) => isFeatureEnabled(key);
 

--- a/src/lib/__tests__/featureFlags.test.ts
+++ b/src/lib/__tests__/featureFlags.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isFeatureEnabled,
+  fetchRemoteFlags,
+  getDevOverrides,
+  setDevOverride,
+  clearDevOverride,
+} from '../featureFlags';
+
+const originalFetch = global.fetch;
+const originalNodeEnv = process.env.NODE_ENV;
+
+describe('featureFlags (#490)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.NODE_ENV = originalNodeEnv;
+    vi.restoreAllMocks();
+  });
+
+  describe('fetchRemoteFlags fallback path', () => {
+    it('falls back to a safe (disabled) definition when the backend is unreachable and there is no cache', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+      const flags = await fetchRemoteFlags();
+      expect(flags.every((f) => f.defaultEnabled === false && f.rolloutPercentage === 0)).toBe(true);
+    });
+
+    it('falls back to the last cached response when the backend is unreachable', async () => {
+      const cached = [
+        { key: 'new_onboarding_flow', name: 'x', description: 'x', defaultEnabled: true, rolloutPercentage: 100 },
+      ];
+      window.localStorage.setItem('ff_remote_cache', JSON.stringify(cached));
+
+      global.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+      const flags = await fetchRemoteFlags();
+      expect(flags).toEqual(cached);
+    });
+
+    it('caches a successful response for future fallback', async () => {
+      const served = [
+        { key: 'new_onboarding_flow', name: 'x', description: 'x', defaultEnabled: false, rolloutPercentage: 50 },
+      ];
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => served,
+      });
+      await fetchRemoteFlags();
+      expect(JSON.parse(window.localStorage.getItem('ff_remote_cache')!)).toEqual(served);
+    });
+  });
+
+  describe('isFeatureEnabled targeting', () => {
+    it('is deterministic for the same session id', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { key: 'rollout_flag', name: 'x', description: 'x', defaultEnabled: false, rolloutPercentage: 50 },
+        ],
+      });
+      await fetchRemoteFlags();
+      const first = isFeatureEnabled('rollout_flag', 'user-123');
+      const second = isFeatureEnabled('rollout_flag', 'user-123');
+      expect(first).toBe(second);
+    });
+
+    it('a 100% rollout is enabled for every user', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { key: 'full_rollout', name: 'x', description: 'x', defaultEnabled: false, rolloutPercentage: 100 },
+        ],
+      });
+      await fetchRemoteFlags();
+      expect(isFeatureEnabled('full_rollout', 'any-user')).toBe(true);
+    });
+
+    it('defaults to disabled for an unknown flag', () => {
+      expect(isFeatureEnabled('does_not_exist', 'user-1')).toBe(false);
+    });
+  });
+
+  describe('dev overrides', () => {
+    it('only persist in development', () => {
+      process.env.NODE_ENV = 'production';
+      setDevOverride('some_flag', true);
+      expect(getDevOverrides()).toEqual({});
+    });
+
+    it('round-trip in development', () => {
+      process.env.NODE_ENV = 'development';
+      setDevOverride('some_flag', true);
+      expect(getDevOverrides()).toEqual({ some_flag: true });
+      clearDevOverride('some_flag');
+      expect(getDevOverrides()).toEqual({});
+    });
+
+    it('degrades to {} for a corrupt stored value', () => {
+      window.localStorage.setItem('ff_dev_overrides', '"not an object"');
+      expect(getDevOverrides()).toEqual({});
+    });
+  });
+});

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -27,19 +27,107 @@ export const FEATURE_FLAGS: FeatureFlag[] = [
   },
 ];
 
+const FLAGS_ENDPOINT = '/api/feature-flags';
+const REMOTE_CACHE_KEY = 'ff_remote_cache';
+const REMOTE_FETCH_TIMEOUT_MS = 3000;
+
+let remoteFlagsMemo: FeatureFlag[] | null = null;
+
+function readCachedRemoteFlags(): FeatureFlag[] | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(REMOTE_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as FeatureFlag[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedRemoteFlags(flags: FeatureFlag[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(REMOTE_CACHE_KEY, JSON.stringify(flags));
+  } catch {
+    // Storage unavailable/full — cache is a best-effort convenience only.
+  }
+}
+
+/**
+ * Fetches flag definitions from the backend so they can be changed without a
+ * client redeploy. Falls back to the last-known-good cache on failure, and
+ * populates `remoteFlagsMemo` so subsequent `isFeatureEnabled` calls in this
+ * session use it without refetching. Never throws — a flag source that can
+ * fail must not be able to crash the app that reads it.
+ */
+export async function fetchRemoteFlags(): Promise<FeatureFlag[]> {
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : undefined;
+  const timeout = controller
+    ? setTimeout(() => controller.abort(), REMOTE_FETCH_TIMEOUT_MS)
+    : undefined;
+  try {
+    const res = await fetch(FLAGS_ENDPOINT, { signal: controller?.signal });
+    if (!res.ok) throw new Error(`Feature flag source returned ${res.status}`);
+    const data = await res.json();
+    if (!Array.isArray(data)) throw new Error('Feature flag source returned an unexpected shape');
+    remoteFlagsMemo = data as FeatureFlag[];
+    writeCachedRemoteFlags(remoteFlagsMemo);
+    return remoteFlagsMemo;
+  } catch {
+    const cached = readCachedRemoteFlags();
+    if (cached) {
+      remoteFlagsMemo = cached;
+      return cached;
+    }
+    // No remote and no cache: fail safe rather than trusting the bundled
+    // defaults, since a future flag could default to enabled.
+    remoteFlagsMemo = FEATURE_FLAGS.map((f) => ({ ...f, defaultEnabled: false, rolloutPercentage: 0 }));
+    return remoteFlagsMemo;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function getFlagDef(key: string): FeatureFlag | undefined {
+  const source = remoteFlagsMemo ?? readCachedRemoteFlags();
+  return (source ?? FEATURE_FLAGS).find((f) => f.key === key);
+}
+
 /**
  * Determines if a feature flag is enabled for the current user/session.
  * Priority order:
  * 1. Developer override (localStorage) — highest priority, dev panel only
  * 2. Environment variable override (NEXT_PUBLIC_FEATURE_FLAGS)
- * 3. Rollout percentage (deterministic based on session ID)
+ * 3. Rollout percentage (deterministic based on the given user/session id,
+ *    so the same user consistently lands on the same side of a gradual
+ *    rollout instead of flipping on every evaluation)
  * 4. Default value
+ *
+ * Until {@link fetchRemoteFlags} has resolved at least once, definitions
+ * fall back to the last cached response, then to the bundled defaults.
  */
 export function isFeatureEnabled(
   key: string,
   sessionId?: string,
 ): boolean {
-  throw new Error('Not implemented: isFeatureEnabled');
+  if (process.env.NODE_ENV === 'development') {
+    const overrides = getDevOverrides();
+    if (key in overrides) return overrides[key];
+  }
+
+  const envFlags = parseEnvFlags();
+  if (key in envFlags) return envFlags[key];
+
+  const flag = getFlagDef(key);
+  if (!flag) return false;
+
+  if (flag.rolloutPercentage <= 0) return flag.defaultEnabled;
+  if (flag.rolloutPercentage >= 100) return true;
+
+  const id = sessionId ?? getSessionId();
+  const bucket = deterministicHash(`${key}:${id}`) % 100;
+  return bucket < flag.rolloutPercentage;
 }
 
 /**
@@ -80,7 +168,23 @@ const DEV_OVERRIDES_KEY = 'ff_dev_overrides';
  * shapes into the feature-flag evaluation path. (#240)
  */
 export function getDevOverrides(): Record<string, boolean> {
-  throw new Error('Not implemented: getDevOverrides');
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(DEV_OVERRIDES_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed) ||
+      !Object.values(parsed).every((v) => typeof v === 'boolean')
+    ) {
+      return {};
+    }
+    return parsed as Record<string, boolean>;
+  } catch {
+    return {};
+  }
 }
 
 /**
@@ -91,7 +195,14 @@ export function getDevOverrides(): Record<string, boolean> {
  * NODE_ENV guard. (#240)
  */
 export function setDevOverride(key: string, enabled: boolean): void {
-  throw new Error('Not implemented: setDevOverride');
+  if (process.env.NODE_ENV !== 'development' || typeof window === 'undefined') return;
+  try {
+    const overrides = getDevOverrides();
+    overrides[key] = enabled;
+    window.localStorage.setItem(DEV_OVERRIDES_KEY, JSON.stringify(overrides));
+  } catch {
+    // Storage unavailable — override simply won't persist this session.
+  }
 }
 
 /**
@@ -101,7 +212,14 @@ export function setDevOverride(key: string, enabled: boolean): void {
  * of which call site invokes it. (#240)
  */
 export function clearDevOverride(key: string): void {
-  throw new Error('Not implemented: clearDevOverride');
+  if (process.env.NODE_ENV !== 'development' || typeof window === 'undefined') return;
+  try {
+    const overrides = getDevOverrides();
+    delete overrides[key];
+    window.localStorage.setItem(DEV_OVERRIDES_KEY, JSON.stringify(overrides));
+  } catch {
+    // Storage unavailable — nothing to clear.
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
`src/lib/featureFlags.ts`, `FeatureFlagPanel.tsx` and `FeatureFlagContext.tsx` existed, but flag definitions were hardcoded on the client — meaning a flag could not be changed without a redeploy, defeating the main reason to have flags (killing a misbehaving feature fast).

- New `src/app/api/feature-flags/route.ts` server route serves `FeatureFlag[]` definitions. It's a real server endpoint decoupled from the client bundle — swapping its data source for a database/config service later requires no client change.
- `fetchRemoteFlags()` in `featureFlags.ts` fetches from that route with a 3s timeout, caches a successful response in `localStorage`, and on failure falls back to the cache, then to a **safe (all-disabled)** definition if there's no cache — a flag source that's down must never fail open.
- `isFeatureEnabled(key, sessionId?)` now supports per-user targeting: rollout-percentage bucketing is keyed on the caller-supplied id (falls back to the existing session id), so the same user consistently lands on the same side of a gradual rollout.
- Dev localStorage overrides are unchanged in behavior but now actually implemented (`getDevOverrides`/`setDevOverride`/`clearDevOverride` were stubs) and remain clearly separate from served values — they're highest priority but only ever settable in `NODE_ENV=development`.
- `FeatureFlagPanel` is now gated to development **or** an explicitly authorised operator in production (`NEXT_PUBLIC_FLAG_PANEL_TOKEN` must be set and match a token stored in that browser's `localStorage`) — it's no longer implicitly restricted by `NODE_ENV` alone.

## Testing
- Added `src/lib/__tests__/featureFlags.test.ts`: remote-unreachable-with-no-cache fail-safe path, remote-unreachable-with-cache fallback path, successful-fetch caching, deterministic per-user targeting, 100% rollout, unknown-flag default, and dev-override round-trip/production no-op/corrupt-storage handling.
- **Not run in this environment**: `npm run lint`, `npm run typecheck`, `npm run test`, `npm run build` — dependencies were not installed per the task constraints (no `npm ci`). Please run the full CI suite before merge.

Closes #490