### PR TITLE
feat(testnet-faucet): add testnet faucet integration for developer on…

### DIFF
--- a/src/__tests__/dashboard-faucet.test.tsx
+++ b/src/__tests__/dashboard-faucet.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createRoot, Root } from "react-dom/client";
+import DashboardPage from "@/components/routes/dashboard-page";
+
+const ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5V3VQ";
+
+const mockUseWallet = vi.hoisted(() => vi.fn());
+
+vi.mock("@/components/wallet-provider", () => ({
+  useWallet: mockUseWallet,
+  WalletProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/stellar", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/stellar")>();
+  return {
+    ...actual,
+    getAccountBalances: vi.fn(async () => ({ total: "0", balances: [] })),
+    fetchRecentTransactions: vi.fn(async () => []),
+    getExplorerUrl: (_network: unknown, _type: unknown, id: string) => `https://stellar.expert/explorer/testnet/account/${id}`,
+    formatNetworkLabel: (_status: unknown, _name?: string | null) => "Testnet",
+    toSafeErrorMessage: (_e: unknown, fallback: string) => fallback,
+    requestTestXLM: actual.requestTestXLM,
+    isValidStellarAddress: vi.fn(() => true),
+  };
+});
+
+vi.mock("@/lib/avatar", () => ({
+  avatarInitials: (_address?: string | null) => "AB",
+  loadAvatar: vi.fn(),
+  saveAvatar: vi.fn(),
+  removeAvatar: vi.fn(),
+  validateAvatarFile: vi.fn(() => ({ ok: true })),
+  isRenderableAvatar: vi.fn(() => true),
+  AVATAR_ACCEPT_ATTR: "image/*",
+}));
+
+vi.mock("@/hooks/useCopyToClipboard", () => ({
+  useCopyToClipboard: () => ({ status: "idle", copy: vi.fn(), reset: vi.fn() }),
+}));
+
+describe("Dashboard faucet", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  const renderDashboard = async (walletOverrides: Partial<ReturnType<typeof mockUseWallet>> = {}) => {
+    mockUseWallet.mockReturnValue({
+      isConnected: true,
+      address: ADDRESS,
+      network: "TESTNET",
+      networkStatus: "TESTNET",
+      walletNetworkName: "TESTNET",
+      isNetworkSupported: true,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      isConnecting: false,
+      networkMismatch: false,
+      dismissNetworkMismatch: vi.fn(),
+      isOnline: true,
+      pendingOperations: [],
+      enqueueOperation: vi.fn(),
+      cancelOperation: vi.fn(),
+      confirmFunding: vi.fn(),
+      ...walletOverrides,
+    });
+
+    await act(async () => {
+      root.render(<DashboardPage />);
+    });
+  };
+
+  it("renders faucet button on testnet when balance is zero", async () => {
+    await renderDashboard();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(container.textContent).toContain("Request Test XLM");
+  });
+
+  it("does not render faucet button on mainnet", async () => {
+    await renderDashboard({ network: "PUBLIC", networkStatus: "PUBLIC" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(container.textContent).not.toContain("Request Test XLM");
+  });
+
+  it("does not render faucet button when wallet is not connected", async () => {
+    await renderDashboard({ isConnected: false, address: null });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(container.textContent).not.toContain("Request Test XLM");
+  });
+
+  it("shows developer checklist when connected", async () => {
+    await renderDashboard();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(container.textContent).toContain("Developer Checklist");
+    expect(container.textContent).toContain("Connect wallet");
+    expect(container.textContent).toContain("Fund account");
+    expect(container.textContent).toContain("Bridge assets");
+  });
+
+  it("does not show developer checklist when not connected", async () => {
+    await renderDashboard({ isConnected: false, address: null });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(container.textContent).not.toContain("Developer Checklist");
+  });
+});

--- a/src/__tests__/faucet.test.ts
+++ b/src/__tests__/faucet.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Keypair } from "@stellar/stellar-sdk";
+import { requestTestXLM } from "@/lib/stellar";
+
+const keypair = Keypair.random();
+const VALID_G_ADDRESS = keypair.publicKey();
+
+describe("requestTestXLM", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns success when faucet responds 200", async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ hash: "abc123def456789" }),
+      } as Response)
+    );
+
+    const result = await requestTestXLM(VALID_G_ADDRESS);
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("Test XLM sent!");
+    expect(result.message).toContain("abc123de...");
+  });
+
+  it("returns rate limit message for 429 response", async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 429,
+      } as Response)
+    );
+
+    const result = await requestTestXLM(VALID_G_ADDRESS);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("rate-limited");
+  });
+
+  it("returns failure for non-429 error responses", async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+      } as Response)
+    );
+
+    const result = await requestTestXLM(VALID_G_ADDRESS);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("500");
+  });
+
+  it("returns failure for invalid address", async () => {
+    const result = await requestTestXLM("invalid");
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Invalid Stellar address.");
+  });
+
+  it("returns failure on network error", async () => {
+    global.fetch = vi.fn(() => Promise.reject(new Error("network down")));
+
+    const result = await requestTestXLM(VALID_G_ADDRESS);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Network error");
+  });
+});

--- a/src/components/routes/dashboard-page.tsx
+++ b/src/components/routes/dashboard-page.tsx
@@ -7,7 +7,7 @@ import AvatarUpload from "@/components/avatar-upload";
 import TransactionHistory from "@/components/transaction-history";
 import LiveRegion from "@/components/live-region";
 import Link from "next/link";
-import { getAccountBalances, fetchRecentTransactions, getExplorerUrl, formatNetworkLabel, toSafeErrorMessage } from "@/lib/stellar";
+import { getAccountBalances, fetchRecentTransactions, getExplorerUrl, formatNetworkLabel, toSafeErrorMessage, requestTestXLM } from "@/lib/stellar";
 import type { BridgeTransactionData } from "@/lib/stellar";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
@@ -35,6 +35,9 @@ export default function DashboardPage() {
   const [transactions, setTransactions] = useState<BridgeTransactionData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [faucetLoading, setFaucetLoading] = useState(false);
+  const [faucetMessage, setFaucetMessage] = useState<string | null>(null);
+  const [faucetError, setFaucetError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isConnected || !address) return;
@@ -115,6 +118,20 @@ export default function DashboardPage() {
         ? "Copy failed. Check clipboard permissions and try again."
         : "";
 
+  const handleFaucet = async () => {
+    if (!address) return;
+    setFaucetLoading(true);
+    setFaucetMessage(null);
+    setFaucetError(null);
+    const result = await requestTestXLM(address);
+    if (result.success) {
+      setFaucetMessage(result.message ?? "Test XLM requested.");
+    } else {
+      setFaucetError(result.message ?? "Faucet request failed.");
+    }
+    setFaucetLoading(false);
+  };
+
   if (!isConnected) {
     return (
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
@@ -157,6 +174,34 @@ export default function DashboardPage() {
       <div className="card p-5 mb-8">
         <AvatarUpload address={address ?? null} />
       </div>
+
+      {isConnected && (
+        <div className="card p-5 mb-8">
+          <h2 className="text-sm font-medium text-[var(--text-muted)] mb-3">Developer Checklist</h2>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm">
+              {isConnected ? <Check className="w-4 h-4 text-[var(--success)]" /> : <X className="w-4 h-4 text-[var(--text-muted)]" />}
+              <span className={isConnected ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}>
+                Connect wallet
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+              {shownBalance !== null && parseFloat(shownBalance) > 0 ? (
+                <Check className="w-4 h-4 text-[var(--success)]" />
+              ) : (
+                <X className="w-4 h-4 text-[var(--text-muted)]" />
+              )}
+              <span className={shownBalance !== null && parseFloat(shownBalance) > 0 ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}>
+                Fund account
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+              <ArrowLeftRight className="w-4 h-4 text-[var(--text-muted)]" />
+              <span className="text-[var(--text-muted)]">Bridge assets</span>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
         <div className="card p-5">
@@ -223,6 +268,30 @@ export default function DashboardPage() {
                 {shownBalance !== null ? parseFloat(shownBalance).toFixed(2) : "—"}
               </div>
               <div className="text-xs text-[var(--text-muted)]">XLM</div>
+              {network === "TESTNET" && !showLoading && (
+                <div className="mt-3">
+                  <button
+                    onClick={handleFaucet}
+                    disabled={faucetLoading}
+                    className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--primary)]/10 text-[var(--primary-light)] text-xs font-medium hover:bg-[var(--primary)]/20 transition-colors disabled:opacity-50"
+                  >
+                    {faucetLoading ? (
+                      <>
+                        <Loader2 className="w-3 h-3 animate-spin motion-reduce:animate-none" />
+                        Requesting...
+                      </>
+                    ) : (
+                      "Request Test XLM"
+                    )}
+                  </button>
+                  {faucetMessage && (
+                    <p className="text-xs text-[var(--success)] mt-2">{faucetMessage}</p>
+                  )}
+                  {faucetError && (
+                    <p className="text-xs text-[var(--error)] mt-2">{faucetError}</p>
+                  )}
+                </div>
+              )}
             </>
           )}
         </div>

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -504,6 +504,61 @@ export async function getRecommendedFee(network: StellarNetwork): Promise<string
 const STROOPS_PER_XLM = 10_000_000;
 
 /**
+ * Stellar testnet friendbot faucet endpoint.
+ */
+const FAUCET_URL = "https://friendbot.stellar.org";
+
+export interface FaucetRequest {
+  success: boolean;
+  message?: string;
+}
+
+/**
+ * Requests test XLM from the Stellar friendbot faucet for the given address.
+ *
+ * - Rate-limited responses (HTTP 429) return a clear message instead of
+ *   silently failing.
+ * - The control is only intended for testnet; callers must gate on
+ *   `network === "TESTNET"` before invoking.
+ */
+export async function requestTestXLM(address: string): Promise<FaucetRequest> {
+  if (!StrKey.isValidEd25519PublicKey(address)) {
+    return { success: false, message: "Invalid Stellar address." };
+  }
+
+  try {
+    const response = await fetch(`${FAUCET_URL}?addr=${encodeURIComponent(address)}`);
+
+    if (response.status === 429) {
+      return {
+        success: false,
+        message: "Faucet is rate-limited. Please wait a few minutes before trying again.",
+      };
+    }
+
+    if (!response.ok) {
+      return {
+        success: false,
+        message: `Faucet request failed (${response.status}). Please try again.`,
+      };
+    }
+
+    const data = (await response.json()) as { hash?: string };
+    return {
+      success: true,
+      message: data.hash
+        ? `Test XLM sent! Transaction: ${data.hash.slice(0, 8)}...${data.hash.slice(-8)}`
+        : "Test XLM request submitted.",
+    };
+  } catch {
+    return {
+      success: false,
+      message: "Network error while contacting faucet. Please check your connection and try again.",
+    };
+  }
+}
+
+/**
  * Fetch the current estimated network fee and return it as a human-readable
  * XLM string suitable for display on the review screen (e.g. "~0.0002 XLM").
  *


### PR DESCRIPTION
…boarding

- Add requestTestXLM() helper in stellar.ts calling friendbot.stellar.org
- Return clear messages for HTTP 429 rate limits and network errors
- Add faucet control to dashboard, gated to TESTNET only
- Add developer checklist (connect, fund, bridge) for first-run guidance
- Add tests for faucet rate limits, mainnet exclusion, and checklist rendering

## Summary

<!-- Provide a brief description of the changes in this PR. -->

## Linked Issue

<!-- Replace #<issue-number> with the actual issue number this PR closes or references. -->
Closes #<issue-number>

## Changes

<!-- List the key changes made in this PR. -->

## Testing

<!-- Describe how you tested the changes locally. -->

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes

## Screenshots

<!-- If this PR includes UI changes, add screenshots or screen recordings here. -->
closes #481 