### PR TITLE
fix(profile): count display name length in code points, not UTF-16 units

### DIFF
--- a/src/lib/__tests__/profile.test.ts
+++ b/src/lib/__tests__/profile.test.ts
@@ -75,6 +75,61 @@ describe('profile store (#325)', () => {
       expect(validateDisplayName('中本聡').ok).toBe(true);
       expect(validateDisplayName('🚀 rocket').ok).toBe(true);
     });
+
+    // --- Unicode / code-point boundary tests (#458) ---
+
+    it('counts each emoji as 1 character, not 2', () => {
+      // 🚀 is U+1F680, a single code point that occupies 2 UTF-16 code units.
+      // 32 emoji must be accepted; 33 must be rejected.
+      const exactly32 = '🚀'.repeat(32);
+      const over32    = '🚀'.repeat(33);
+
+      expect(validateDisplayName(exactly32).ok).toBe(true);
+
+      const result = validateDisplayName(over32);
+      expect(result.ok).toBe(false);
+      // The error must report 33 (code points), not 66 (UTF-16 code units).
+      expect(result.ok === false && result.error).toContain('33');
+    });
+
+    it('counts astral-plane characters (𝄞 U+1D11E) as 1 each', () => {
+      // Musical symbol G-CLEF — U+1D11E — lives outside the BMP.
+      const exactly32 = '𝄞'.repeat(32);
+      const over32    = '𝄞'.repeat(33);
+
+      expect(validateDisplayName(exactly32).ok).toBe(true);
+      expect(validateDisplayName(over32).ok).toBe(false);
+    });
+
+    it('counts a combining-mark sequence as its constituent code points', () => {
+      // "e\u0301" is two code points (LATIN SMALL LETTER E + COMBINING ACUTE
+      // ACCENT) that render as one glyph "é". The limit applies to code points,
+      // so 16 of these pairs = 32 code points → accepted; 17 pairs = 34 → rejected.
+      const e_acute = 'e\u0301'; // 2 code points
+      const exactly32 = e_acute.repeat(16); // 16 × 2 = 32 code points
+      const over32    = e_acute.repeat(17); // 17 × 2 = 34 code points
+
+      expect(validateDisplayName(exactly32).ok).toBe(true);
+      expect(validateDisplayName(over32).ok).toBe(false);
+    });
+
+    it('reports the code-point count in the error, not the UTF-16 length', () => {
+      // A name of 33 emoji: code-point length 33, UTF-16 length 66.
+      const name = '😀'.repeat(33);
+      const result = validateDisplayName(name);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        // Must mention 33 (actual code-point count), not 66 (UTF-16 units).
+        expect(result.error).toContain('33');
+        expect(result.error).not.toContain('66');
+      }
+    });
+
+    it('accepts a mixed ASCII + emoji name within the code-point limit', () => {
+      // "Hi 🎉🎉🎉" = 3 + 1 + 3 = 7 code points — well within 32.
+      expect(validateDisplayName('Hi 🎉🎉🎉').ok).toBe(true);
+    });
   });
 
   describe('isRenderableDisplayName', () => {

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -16,13 +16,30 @@
  */
 
 /**
- * 32 characters. Long enough for a real name or handle, short enough to render
+ * 32 code points. Long enough for a real name or handle, short enough to render
  * on one line next to the avatar without truncation at mobile widths.
+ *
+ * The cap is measured in **Unicode code points** (i.e. `[...value].length`),
+ * not UTF-16 code units (`String.prototype.length`). This means emoji and other
+ * astral-plane characters each count as 1, matching what the user sees on
+ * screen. (#458)
  */
 export const DISPLAY_NAME_MAX_LENGTH = 32;
 
 const STORAGE_PREFIX = "profile:";
 const NAME_SUFFIX = ":name";
+
+/**
+ * Count the number of Unicode code points in a string.
+ *
+ * JavaScript's `String.prototype.length` returns the number of UTF-16 code
+ * units, which double-counts any character outside the Basic Multilingual Plane
+ * (e.g. emoji, mathematical symbols). Spreading the string into an array
+ * iterates by code point instead, giving the count a user would expect. (#458)
+ */
+function codePointLength(value: string): number {
+  return [...value].length;
+}
 
 /**
  * True when `value` holds a C0/C1 control character, a bidi mark, or a bidi
@@ -49,7 +66,7 @@ export type DisplayNameValidation =
 
 /** Storage key for an address. Exported so tests and docs can reference it. */
 export function displayNameStorageKey(address: string): string {
-  throw new Error('Not implemented: displayNameStorageKey');
+  return `${STORAGE_PREFIX}${address}${NAME_SUFFIX}`;
 }
 
 /**
@@ -58,14 +75,44 @@ export function displayNameStorageKey(address: string): string {
  * Returns the trimmed value on success so callers store exactly what was
  * validated — validating one string and persisting another is how a rule like
  * the length cap gets bypassed by trailing whitespace.
+ *
+ * Length is measured in **Unicode code points** so that emoji and other
+ * astral-plane characters count as 1 against the cap, matching what the user
+ * sees on screen. (#458)
  */
 export function validateDisplayName(raw: string): DisplayNameValidation {
-  throw new Error('Not implemented: validateDisplayName');
+  const trimmed = raw.trim();
+
+  if (trimmed.length === 0) {
+    return { ok: false, error: "Enter a display name." };
+  }
+
+  // Count code points, not UTF-16 code units, so emoji count as 1. (#458)
+  const len = codePointLength(trimmed);
+  if (len > DISPLAY_NAME_MAX_LENGTH) {
+    return {
+      ok: false,
+      error: `Display name is too long — the limit is ${DISPLAY_NAME_MAX_LENGTH} characters (yours is ${len}).`,
+    };
+  }
+
+  if (hasControlChars(trimmed)) {
+    return {
+      ok: false,
+      error: "Display name contains invalid characters.",
+    };
+  }
+
+  return { ok: true, value: trimmed };
 }
 
 /** True when `value` came out of storage in a shape that is safe to render. */
 export function isRenderableDisplayName(value: unknown): value is string {
-  throw new Error('Not implemented: isRenderableDisplayName');
+  if (typeof value !== "string") return false;
+  // Must be trimmed (saveDisplayName always stores the trimmed form).
+  if (value !== value.trim()) return false;
+  // Re-run the same validation used at write time.
+  return validateDisplayName(value).ok;
 }
 
 function storage(): Storage | null {
@@ -80,7 +127,19 @@ function storage(): Storage | null {
 
 /** Reads the stored display name for `address`, or null when absent/invalid. */
 export function loadDisplayName(address: string | null | undefined): string | null {
-  throw new Error('Not implemented: loadDisplayName');
+  if (!address) return null;
+  const store = storage();
+  if (!store) return null;
+
+  let raw: string | null;
+  try {
+    raw = store.getItem(displayNameStorageKey(address));
+  } catch {
+    return null;
+  }
+
+  if (raw === null) return null;
+  return isRenderableDisplayName(raw) ? raw : null;
 }
 
 /**
@@ -92,18 +151,45 @@ export function saveDisplayName(
   address: string | null | undefined,
   name: string,
 ): boolean {
-  throw new Error('Not implemented: saveDisplayName');
+  if (!address) return false;
+  const store = storage();
+  if (!store) return false;
+
+  const validation = validateDisplayName(name);
+  if (!validation.ok) return false;
+
+  try {
+    store.setItem(displayNameStorageKey(address), validation.value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Removes the stored display name for `address`. */
 export function clearDisplayName(address: string | null | undefined): void {
-  throw new Error('Not implemented: clearDisplayName');
+  if (!address) return;
+  const store = storage();
+  if (!store) return;
+
+  try {
+    store.removeItem(displayNameStorageKey(address));
+  } catch {
+    // Swallow — nothing useful to do if removal fails.
+  }
 }
 
 /**
  * Short form of a Stellar address for display: `GABC…WXYZ`. Falls back to the
  * whole string when it is too short to shorten meaningfully.
+ *
+ * Stellar addresses are Base32-encoded and contain only ASCII characters, so
+ * `String.prototype.slice` is safe here without any code-point awareness.
  */
 export function shortenAddress(address: string | null | undefined): string {
-  throw new Error('Not implemented: shortenAddress');
+  if (!address) return "";
+  // Keep at least 12 characters (6 + 6) before eliding; shorter strings are
+  // returned as-is so the display never shows "GA…" with nothing after.
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}…${address.slice(-6)}`;
 }


### PR DESCRIPTION
## Summary

`validateDisplayName` in `src/lib/profile.ts` used `String.prototype.length` which counts UTF-16 code units. Characters outside the Basic Multilingual Plane (emoji, musical symbols, etc.) occupy two code units, so a 20-emoji name was rejected as "40 characters" — and that inflated number was reported back to the user.

`hasControlChars` in the same file already iterated by code point via `for...of`; the two functions disagreed on what "a character" is.

## Changes

- Add `codePointLength()` helper using `[...value].length` which iterates by code point
- Switch the length cap in `validateDisplayName` to use code points (#458)
- Error message now reports the code-point count the user actually sees
- Implement all remaining stub functions: `displayNameStorageKey`, `isRenderableDisplayName`, `loadDisplayName`, `saveDisplayName`, `clearDisplayName`, `shortenAddress`
- Document that the cap is measured in code points (not grapheme clusters)

## Tests added

- 32 emoji accepted, 33 rejected — each counts as 1, not 2
- Astral-plane character U+1D11E (𝄞) counts as 1
- Combining-mark pair (e + U+0301) counts as 2 code points
- Error message reports the code-point count, not the UTF-16 length
- Mixed ASCII + emoji within limit is accepted

All 56 profile tests pass (30 unit + 26 page). Pre-existing build/lint failures in `wallet-provider.tsx` are unrelated to this change.

Closes #458