### PR TITLE
Implement cache decision helpers in serviceWorker.ts (#535, #536, #537, #538)

### DIFF
--- a/src/lib/serviceWorker.ts
+++ b/src/lib/serviceWorker.ts
@@ -119,7 +119,7 @@ export function isCacheableResponse(response: {
 
 /** Registration is opt-in, so a stale cached shell can never surprise a deploy. */
 export function isServiceWorkerEnabled(): boolean {
-  throw new Error('Not implemented: isServiceWorkerEnabled');
+  return process.env.NEXT_PUBLIC_ENABLE_SW === "true";
 }
 
 interface NavigatorLike {

--- a/src/lib/serviceWorker.ts
+++ b/src/lib/serviceWorker.ts
@@ -113,7 +113,8 @@ export function isCacheableResponse(response: {
   status?: number;
   type?: string;
 } | null | undefined): boolean {
-  throw new Error('Not implemented: isCacheableResponse');
+  if (!response) return false;
+  return response.ok === true && response.status !== 206 && response.type === "basic";
 }
 
 /** Registration is opt-in, so a stale cached shell can never surprise a deploy. */

--- a/src/lib/serviceWorker.ts
+++ b/src/lib/serviceWorker.ts
@@ -104,7 +104,7 @@ export function cacheStrategyFor(request: RequestLike, origin: string): CacheStr
 
 /** True for caches this app owns from an older worker version — deleted on activate. */
 export function isStaleCache(cacheName: string): boolean {
-  throw new Error('Not implemented: isStaleCache');
+  return cacheName.startsWith(SW_CACHE_PREFIX) && cacheName !== SW_CACHE_NAME;
 }
 
 /** Only responses that are OK, basic (same-origin) and non-partial are worth storing. */

--- a/src/lib/serviceWorker.ts
+++ b/src/lib/serviceWorker.ts
@@ -85,7 +85,8 @@ export function shouldBypassCache(request: RequestLike): boolean {
 
 /** True when the pathname points at a static asset that is safe to serve cache-first. */
 export function isCacheableAsset(pathname: string): boolean {
-  throw new Error('Not implemented: isCacheableAsset');
+  const lower = pathname.toLowerCase();
+  return CACHEABLE_EXTENSIONS.some((ext) => lower.endsWith(ext));
 }
 
 /**


### PR DESCRIPTION
## Title

Implement cache decision helpers in serviceWorker.ts (#535, #536, #537, #538)

## Body

This PR implements four pure decision-logic functions in `src/lib/serviceWorker.ts`:

**`isCacheableAsset(pathname)`** (#535) — returns true when the pathname's extension (case-insensitive) is one of the entries in `CACHEABLE_EXTENSIONS`, identifying static assets safe to serve cache-first.

**`isStaleCache(cacheName)`** (#536) — returns true when a cache name belongs to this app (`SW_CACHE_PREFIX`) but isn't the current version (`SW_CACHE_NAME`), so old versions get cleaned up on activate without touching caches owned by other code.

**`isCacheableResponse(response)`** (#537) — returns true only for responses that are `ok`, `type === "basic"` (same-origin, non-opaque), and not a `206` partial-content status; guards against `null`/`undefined`.

**`isServiceWorkerEnabled()`** (#538) — returns true only when `process.env.NEXT_PUBLIC_ENABLE_SW === "true"`, keeping registration strictly opt-in.

All four match the documented contracts on their existing signatures/doc comments — only function bodies changed.

Closes #535
Closes #536
Closes #537
Closes #538
