### PR TITLE
Add test coverage for sequenceManager and implement shouldBypassCache

### DIFF
--- a/src/__tests__/sequenceManager.test.ts
+++ b/src/__tests__/sequenceManager.test.ts
@@ -512,5 +512,10 @@ describe("sequenceManager", () => {
       expect(result2).toBe(201n);
       expect(mockHorizonServer.loadAccount).toHaveBeenCalledTimes(4);
     });
+
+    it("is a no-op and does not throw when the cache is already empty", () => {
+      expect(() => clearAllSequenceCache()).not.toThrow();
+      expect(() => clearAllSequenceCache()).not.toThrow();
+    });
   });
 });

--- a/src/__tests__/sequenceManager.test.ts
+++ b/src/__tests__/sequenceManager.test.ts
@@ -501,6 +501,30 @@ describe("sequenceManager", () => {
 
       expect(result).toBe("success");
     });
+
+    it("defaults maxRetries to 1, giving up after a single retry", async () => {
+      const mockAccount = { sequenceNumber: () => "100" };
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValue(mockAccount);
+
+      const badSeqError = {
+        response: {
+          data: {
+            extras: { result_codes: { transaction: "tx_bad_seq" } },
+          },
+        },
+      };
+
+      const fn = vi.fn().mockRejectedValue(badSeqError);
+
+      // No maxRetries argument passed - should use the default of 1.
+      const promise = withSequenceRetry(testAccountId, fn, mockHorizonServer, "TESTNET");
+      const expectation = expect(promise).rejects.toEqual(badSeqError);
+      await vi.runAllTimersAsync();
+      await expectation;
+
+      // Initial attempt + 1 retry = 2 calls total.
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("clearAllSequenceCache", () => {

--- a/src/__tests__/sequenceManager.test.ts
+++ b/src/__tests__/sequenceManager.test.ts
@@ -317,6 +317,25 @@ describe("sequenceManager", () => {
       expect(isBadSequenceError({})).toBe(false);
       expect(isBadSequenceError("some string")).toBe(false);
     });
+
+    it("returns false for a Horizon-shaped error missing the result_codes", () => {
+      expect(isBadSequenceError({ response: {} })).toBe(false);
+      expect(isBadSequenceError({ response: { data: {} } })).toBe(false);
+      expect(isBadSequenceError({ response: { data: { extras: {} } } })).toBe(false);
+    });
+
+    it("returns false for a Horizon-shaped error with an unrelated result code", () => {
+      const error = {
+        response: {
+          data: {
+            extras: {
+              result_codes: { transaction: "tx_insufficient_balance" },
+            },
+          },
+        },
+      };
+      expect(isBadSequenceError(error)).toBe(false);
+    });
   });
 
   describe("withSequenceRetry", () => {

--- a/src/lib/serviceWorker.ts
+++ b/src/lib/serviceWorker.ts
@@ -80,7 +80,19 @@ function parseUrl(url: string): URL | null {
  * request-specific and may carry user data.
  */
 export function shouldBypassCache(request: RequestLike): boolean {
-  throw new Error('Not implemented: shouldBypassCache');
+  const method = (request.method ?? "GET").toUpperCase();
+  if (method !== "GET") return true;
+
+  const url = parseUrl(request.url);
+  if (!url) return true;
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") return true;
+
+  if (NEVER_CACHE_ORIGINS.some((origin) => request.url.startsWith(origin))) return true;
+
+  if (url.pathname === "/api" || url.pathname.startsWith("/api/")) return true;
+
+  return false;
 }
 
 /** True when the pathname points at a static asset that is safe to serve cache-first. */


### PR DESCRIPTION
## Title
Add test coverage for sequenceManager and implement shouldBypassCache

## Body
This PR addresses #531, #532, #533, and #534.

`clearAllSequenceCache()`, `isBadSequenceError()`, and `withSequenceRetry()` in `src/lib/sequenceManager.ts` were already fully implemented on `main` with solid existing test coverage. Rather than touch working logic, I added a focused test for each: `clearAllSequenceCache` calling it on an already-empty cache stays a safe no-op; `isBadSequenceError` correctly returns `false` for malformed/partial Horizon error shapes (missing `data`, missing `extras`, missing `result_codes`) and for an unrelated result code, instead of only the happy paths already covered; `withSequenceRetry` verifies its default `maxRetries` value of 1 actually caps retries at a single extra attempt (2 total calls) when no explicit value is passed, which the existing suite only exercised with an explicit `maxRetries`.

`shouldBypassCache()` in `src/lib/serviceWorker.ts` was a genuine stub throwing "Not implemented". I implemented the real routing logic per its docstring and the existing `src/__tests__/serviceWorker.test.ts` spec: bypass any non-GET method, any unparseable URL, any non-http(s) scheme, any Stellar network origin in `NEVER_CACHE_ORIGINS`, and any `/api` or `/api/*` path — everything else falls through to be handled by the cache strategy.

Closes #531
Closes #532
Closes #533
Closes #534
