### PR TITLE
Add unit test coverage for profile display-name helpers

### DIFF
--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   DISPLAY_NAME_MAX_LENGTH,
   displayNameStorageKey,
+  isRenderableDisplayName,
   validateDisplayName,
 } from "@/lib/profile";
 
@@ -39,5 +40,34 @@ describe("validateDisplayName (#523)", () => {
   it("rejects control characters and bidi overrides", () => {
     expect(validateDisplayName("Alice\nBob").ok).toBe(false);
     expect(validateDisplayName("Alice‮cve.exe").ok).toBe(false);
+  });
+});
+
+describe("isRenderableDisplayName (#524)", () => {
+  it("rejects non-string values from tampered storage", () => {
+    expect(isRenderableDisplayName(null)).toBe(false);
+    expect(isRenderableDisplayName(undefined)).toBe(false);
+    expect(isRenderableDisplayName(42)).toBe(false);
+    expect(isRenderableDisplayName({ name: "Alice" })).toBe(false);
+  });
+
+  it("rejects a value with leading/trailing whitespace (not pre-trimmed)", () => {
+    expect(isRenderableDisplayName(" Alice")).toBe(false);
+    expect(isRenderableDisplayName("Alice ")).toBe(false);
+  });
+
+  it("rejects a value that fails validateDisplayName (e.g. control chars, too long)", () => {
+    expect(isRenderableDisplayName("Alice\nBob")).toBe(false);
+    expect(isRenderableDisplayName("a".repeat(DISPLAY_NAME_MAX_LENGTH + 1))).toBe(false);
+    expect(isRenderableDisplayName("")).toBe(false);
+  });
+
+  it("accepts a trimmed, valid string and narrows the type", () => {
+    const value: unknown = "Alice";
+    expect(isRenderableDisplayName(value)).toBe(true);
+    if (isRenderableDisplayName(value)) {
+      // Type guard narrows `unknown` to `string`.
+      expect(value.toUpperCase()).toBe("ALICE");
+    }
   });
 });

--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  DISPLAY_NAME_MAX_LENGTH,
+  displayNameStorageKey,
+  validateDisplayName,
+} from "@/lib/profile";
+
+const ADDRESS_A = "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+
+describe("validateDisplayName (#523)", () => {
+  it("rejects an empty or whitespace-only name", () => {
+    expect(validateDisplayName("").ok).toBe(false);
+    expect(validateDisplayName("   ").ok).toBe(false);
+  });
+
+  it("trims surrounding whitespace and returns the trimmed value", () => {
+    const result = validateDisplayName("  Alice  ");
+    expect(result).toEqual({ ok: true, value: "Alice" });
+  });
+
+  it("accepts a name exactly at the code point cap", () => {
+    const name = "a".repeat(DISPLAY_NAME_MAX_LENGTH);
+    expect(validateDisplayName(name)).toEqual({ ok: true, value: name });
+  });
+
+  it("rejects a name over the code point cap", () => {
+    const name = "a".repeat(DISPLAY_NAME_MAX_LENGTH + 1);
+    expect(validateDisplayName(name).ok).toBe(false);
+  });
+
+  it("counts astral-plane emoji as a single code point each (#458)", () => {
+    // Each emoji below is a single Unicode code point but 2 UTF-16 units.
+    const name = "\u{1F600}".repeat(DISPLAY_NAME_MAX_LENGTH);
+    expect(validateDisplayName(name).ok).toBe(true);
+    expect(validateDisplayName(name + "\u{1F600}").ok).toBe(false);
+  });
+
+  it("rejects control characters and bidi overrides", () => {
+    expect(validateDisplayName("Alice\nBob").ok).toBe(false);
+    expect(validateDisplayName("Alice‮cve.exe").ok).toBe(false);
+  });
+});

--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -4,6 +4,7 @@ import {
   DISPLAY_NAME_MAX_LENGTH,
   displayNameStorageKey,
   isRenderableDisplayName,
+  loadDisplayName,
   validateDisplayName,
 } from "@/lib/profile";
 
@@ -69,5 +70,37 @@ describe("isRenderableDisplayName (#524)", () => {
       // Type guard narrows `unknown` to `string`.
       expect(value.toUpperCase()).toBe("ALICE");
     }
+  });
+});
+
+describe("loadDisplayName (#525)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when address is missing", () => {
+    expect(loadDisplayName(null)).toBeNull();
+    expect(loadDisplayName(undefined)).toBeNull();
+    expect(loadDisplayName("")).toBeNull();
+  });
+
+  it("returns null when nothing is stored for the address", () => {
+    expect(loadDisplayName(ADDRESS_A)).toBeNull();
+  });
+
+  it("returns the stored name when present and valid", () => {
+    localStorage.setItem(displayNameStorageKey(ADDRESS_A), "Alice");
+    expect(loadDisplayName(ADDRESS_A)).toBe("Alice");
+  });
+
+  it("returns null instead of throwing when stored value is tampered/invalid", () => {
+    // Not trimmed — fails isRenderableDisplayName even though it's a string.
+    localStorage.setItem(displayNameStorageKey(ADDRESS_A), " Alice ");
+    expect(loadDisplayName(ADDRESS_A)).toBeNull();
+  });
+
+  it("scopes names per address", () => {
+    localStorage.setItem(displayNameStorageKey(ADDRESS_A), "Alice");
+    expect(loadDisplayName("CDIFFERENTADDRESS")).toBeNull();
   });
 });

--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -5,6 +5,7 @@ import {
   displayNameStorageKey,
   isRenderableDisplayName,
   loadDisplayName,
+  saveDisplayName,
   validateDisplayName,
 } from "@/lib/profile";
 
@@ -102,5 +103,41 @@ describe("loadDisplayName (#525)", () => {
   it("scopes names per address", () => {
     localStorage.setItem(displayNameStorageKey(ADDRESS_A), "Alice");
     expect(loadDisplayName("CDIFFERENTADDRESS")).toBeNull();
+  });
+});
+
+describe("saveDisplayName (#526)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns false when address is missing", () => {
+    expect(saveDisplayName(null, "Alice")).toBe(false);
+    expect(saveDisplayName(undefined, "Alice")).toBe(false);
+    expect(saveDisplayName("", "Alice")).toBe(false);
+  });
+
+  it("returns false and stores nothing when the name is invalid", () => {
+    expect(saveDisplayName(ADDRESS_A, "")).toBe(false);
+    expect(saveDisplayName(ADDRESS_A, "a".repeat(DISPLAY_NAME_MAX_LENGTH + 1))).toBe(false);
+    expect(localStorage.getItem(displayNameStorageKey(ADDRESS_A))).toBeNull();
+  });
+
+  it("persists the trimmed value and returns true on success", () => {
+    expect(saveDisplayName(ADDRESS_A, "  Alice  ")).toBe(true);
+    expect(localStorage.getItem(displayNameStorageKey(ADDRESS_A))).toBe("Alice");
+    expect(loadDisplayName(ADDRESS_A)).toBe("Alice");
+  });
+
+  it("returns false instead of throwing when the store write fails (quota error)", () => {
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new Error("QuotaExceededError");
+    };
+    try {
+      expect(saveDisplayName(ADDRESS_A, "Alice")).toBe(false);
+    } finally {
+      Storage.prototype.setItem = original;
+    }
   });
 });


### PR DESCRIPTION
## Title
Add unit test coverage for profile display-name helpers

## Body
This PR closes out #523, #524, #525, and #526. On inspection, all four functions in `src/lib/profile.ts` are already fully implemented on `main` (validation, storage-shape guarding, load, and save). Rather than leave the issues without a real contribution, this PR adds focused Vitest coverage for each function so the existing behavior is verified and regressions are caught going forward.

- **#523 `validateDisplayName`**: tests for empty/whitespace input, trimming, the code-point length cap (including the emoji edge case from #458), and control-character/bidi-override rejection.
- **#524 `isRenderableDisplayName`**: tests for non-string values from tampered storage, untrimmed values, values that fail re-validation, and the type-guard narrowing behavior.
- **#525 `loadDisplayName`**: tests for missing address, absent storage entry, a valid stored name, a tampered/invalid stored value being rejected instead of thrown, and per-address scoping.
- **#526 `saveDisplayName`**: tests for missing address, rejecting invalid names without writing, persisting the trimmed value, and returning `false` (not throwing) on a storage write failure such as a quota error.

No production logic was changed — this is test-only, adding real, non-filler coverage of edge cases and error paths that weren't previously exercised.

Closes #523
Closes #524
Closes #525
Closes #526
