### PR TITLE
Add unit test coverage for profile and sequenceManager functions (#527-#530)

### DIFF
--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from "vitest";
-import { clearDisplayName, displayNameStorageKey, saveDisplayName } from "@/lib/profile";
+import {
+  clearDisplayName,
+  displayNameStorageKey,
+  saveDisplayName,
+  shortenAddress,
+} from "@/lib/profile";
 
 const ADDRESS_A = "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
 const ADDRESS_B = "CABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
@@ -37,5 +42,30 @@ describe("clearDisplayName (#527)", () => {
   it("is a no-op when nothing was ever stored for the address", () => {
     expect(() => clearDisplayName(ADDRESS_A)).not.toThrow();
     expect(window.localStorage.getItem(displayNameStorageKey(ADDRESS_A))).toBeNull();
+  });
+});
+
+describe("shortenAddress (#528)", () => {
+  it("keeps the first 6 and last 6 characters, joined by an ellipsis", () => {
+    const result = shortenAddress(ADDRESS_A);
+    expect(result).toBe(`${ADDRESS_A.slice(0, 6)}…${ADDRESS_A.slice(-6)}`);
+    expect(result.startsWith(ADDRESS_A.slice(0, 6))).toBe(true);
+    expect(result.endsWith(ADDRESS_A.slice(-6))).toBe(true);
+  });
+
+  it("returns strings of 12 characters or fewer unchanged", () => {
+    expect(shortenAddress("123456789012")).toBe("123456789012"); // exactly 12
+    expect(shortenAddress("short")).toBe("short");
+    expect(shortenAddress("")).toBe("");
+  });
+
+  it("shortens strings of 13 characters or more", () => {
+    const address = "1234567890123"; // 13 chars
+    expect(shortenAddress(address)).toBe("123456…890123");
+  });
+
+  it("returns an empty string for null/undefined input", () => {
+    expect(shortenAddress(null)).toBe("");
+    expect(shortenAddress(undefined)).toBe("");
   });
 });

--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { clearDisplayName, displayNameStorageKey, saveDisplayName } from "@/lib/profile";
+
+const ADDRESS_A = "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+const ADDRESS_B = "CABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("clearDisplayName (#527)", () => {
+  it("removes the stored name for the given address", () => {
+    saveDisplayName(ADDRESS_A, "Alice");
+    expect(window.localStorage.getItem(displayNameStorageKey(ADDRESS_A))).toBe("Alice");
+
+    clearDisplayName(ADDRESS_A);
+
+    expect(window.localStorage.getItem(displayNameStorageKey(ADDRESS_A))).toBeNull();
+  });
+
+  it("only clears the given address, leaving other addresses untouched", () => {
+    saveDisplayName(ADDRESS_A, "Alice");
+    saveDisplayName(ADDRESS_B, "Bob");
+
+    clearDisplayName(ADDRESS_A);
+
+    expect(window.localStorage.getItem(displayNameStorageKey(ADDRESS_A))).toBeNull();
+    expect(window.localStorage.getItem(displayNameStorageKey(ADDRESS_B))).toBe("Bob");
+  });
+
+  it("is a no-op for a null/undefined address (does not throw)", () => {
+    expect(() => clearDisplayName(null)).not.toThrow();
+    expect(() => clearDisplayName(undefined)).not.toThrow();
+  });
+
+  it("is a no-op when nothing was ever stored for the address", () => {
+    expect(() => clearDisplayName(ADDRESS_A)).not.toThrow();
+    expect(window.localStorage.getItem(displayNameStorageKey(ADDRESS_A))).toBeNull();
+  });
+});

--- a/src/__tests__/sequenceManager.test.ts
+++ b/src/__tests__/sequenceManager.test.ts
@@ -86,6 +86,27 @@ describe("sequenceManager", () => {
       expect(mockHorizonServer.loadAccount).toHaveBeenCalledTimes(2);
     });
 
+    it("propagates a network fetch error without caching a bad entry (#529)", async () => {
+      (mockHorizonServer.loadAccount as Mock).mockRejectedValueOnce(
+        new Error("network unreachable")
+      );
+
+      await expect(
+        getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET")
+      ).rejects.toThrow("network unreachable");
+
+      // A failed fetch must not poison the cache — the next call should
+      // retry against the network rather than serving/incrementing a
+      // partial or missing entry.
+      (mockHorizonServer.loadAccount as Mock).mockResolvedValueOnce({
+        sequenceNumber: () => "100",
+      });
+
+      const result = await getNextSequenceNumber(testAccountId, mockHorizonServer, "TESTNET");
+      expect(result).toBe(101n);
+      expect(mockHorizonServer.loadAccount).toHaveBeenCalledTimes(2);
+    });
+
     it("handles SorobanRpc server", async () => {
       const mockAccount = { sequenceNumber: () => "100" };
       (mockSorobanRpcServer.getAccount as Mock).mockResolvedValue(mockAccount);

--- a/src/__tests__/sequenceManager.test.ts
+++ b/src/__tests__/sequenceManager.test.ts
@@ -246,6 +246,10 @@ describe("sequenceManager", () => {
   });
 
   describe("invalidateSequenceCache", () => {
+    it("is a no-op when the account/network was never cached (#530)", () => {
+      expect(() => invalidateSequenceCache(testAccountId, "TESTNET")).not.toThrow();
+    });
+
     it("causes refetch on next call", async () => {
       const mockAccount = { sequenceNumber: () => "100" };
       (mockHorizonServer.loadAccount as Mock).mockResolvedValue(mockAccount);


### PR DESCRIPTION
## Title
Add unit test coverage for profile and sequenceManager functions (#527-#530)

## Body
On rebasing onto latest `main`, all four functions targeted by these issues (`clearDisplayName`, `shortenAddress`, `getNextSequenceNumber`, `invalidateSequenceCache`) were found to already be fully implemented rather than stubs. Since they already satisfy their documented contracts, this PR adds genuine test coverage for each instead of touching the implementations.

**#527 — `clearDisplayName()`**: Added `src/__tests__/profile.test.ts` with tests verifying it removes only the given address's stored name, leaves other addresses untouched, and no-ops safely on null/undefined or already-empty storage.

**#528 — `shortenAddress()`**: Added tests in the same file covering the `GABC…WXYZ` truncation format, the 12-character unshortened boundary, the 13-character shortening threshold, and null/undefined handling.

**#529 — `getNextSequenceNumber()`**: Added a test to `src/__tests__/sequenceManager.test.ts` confirming a failed network fetch propagates its error without poisoning the cache — a subsequent call correctly retries against the network rather than serving a partial/missing entry.

**#530 — `invalidateSequenceCache()`**: Added a test confirming invalidating an account/network pair that was never cached is a safe no-op.

Closes #527
Closes #528
Closes #529
Closes #530
