### PR TITLE
fix(session, stellar): preserve selectedWalletId on connect/disconnect; add coverage for clearSession and getHorizonServer

### DIFF
--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -103,4 +103,24 @@ describe("wallet session persistence (#343)", () => {
     expect(session.manuallyDisconnected).toBe(false);
     expect(session.address).toBeNull();
   });
+
+  it("markConnected preserves a previously persisted selectedWalletId (#459)", () => {
+    localStorage.setItem(
+      SESSION_STORAGE_KEY,
+      JSON.stringify({ address: null, manuallyDisconnected: true, updatedAt: NOW, selectedWalletId: "xbull" })
+    );
+    const result = markConnected(ADDRESS, NOW + 1000);
+    expect(result.selectedWalletId).toBe("xbull");
+    expect(loadSession(NOW + 2000).selectedWalletId).toBe("xbull");
+  });
+
+  it("markDisconnected preserves a previously persisted selectedWalletId (#459)", () => {
+    localStorage.setItem(
+      SESSION_STORAGE_KEY,
+      JSON.stringify({ address: ADDRESS, manuallyDisconnected: false, updatedAt: NOW, selectedWalletId: "lobstr" })
+    );
+    const result = markDisconnected(ADDRESS, NOW + 1000);
+    expect(result.selectedWalletId).toBe("lobstr");
+    expect(loadSession(NOW + 2000).selectedWalletId).toBe("lobstr");
+  });
 });

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   SESSION_STORAGE_KEY,
   SESSION_TTL_MS,
@@ -66,6 +66,23 @@ describe("wallet session persistence (#343)", () => {
     markDisconnected(ADDRESS, NOW);
     clearSession();
     expect(loadSession(NOW).manuallyDisconnected).toBe(false);
+    expect(localStorage.getItem(SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it("clearSession is a no-op when nothing is stored", () => {
+    expect(() => clearSession()).not.toThrow();
+    expect(localStorage.getItem(SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it("clearSession swallows removeItem failures (privacy-mode storage)", () => {
+    const removeItem = vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    try {
+      expect(() => clearSession()).not.toThrow();
+    } finally {
+      removeItem.mockRestore();
+    }
   });
 
   it("isSessionExpired brackets the TTL", () => {

--- a/src/__tests__/stellar.test.ts
+++ b/src/__tests__/stellar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { Keypair, StrKey } from "@stellar/stellar-sdk";
+import { Keypair, StrKey, Horizon } from "@stellar/stellar-sdk";
 import {
   isValidStellarAddress,
   isCAddress,
@@ -7,7 +7,9 @@ import {
   isValidStellarAmount,
   getAccountBalances,
   clearAccountBalancesCache,
+  getHorizonServer,
 } from "@/lib/stellar";
+import { HORIZON_URL } from "@/lib/types";
 
 // Horizon's network call is the only thing stubbed; every other SDK export
 // (Keypair, StrKey, ...) stays real so the address fixtures below are genuine
@@ -279,5 +281,25 @@ describe("getAccountBalances cache", () => {
     await getAccountBalances(G_ADDRESS, "TESTNET");
 
     expect(loadAccount).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("getHorizonServer", () => {
+  beforeEach(() => {
+    (Horizon.Server as unknown as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it("builds a Horizon server pointed at the network's Horizon URL", async () => {
+    await getHorizonServer("PUBLIC");
+    expect(Horizon.Server).toHaveBeenCalledWith(HORIZON_URL.PUBLIC);
+  });
+
+  it("uses the testnet Horizon URL for TESTNET", async () => {
+    await getHorizonServer("TESTNET");
+    expect(Horizon.Server).toHaveBeenCalledWith(HORIZON_URL.TESTNET);
+  });
+
+  it("PUBLIC and TESTNET resolve to distinct Horizon URLs", () => {
+    expect(HORIZON_URL.PUBLIC).not.toBe(HORIZON_URL.TESTNET);
   });
 });

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -124,6 +124,7 @@ export function markDisconnected(address: string | null = null, now: number = Da
     address: address ?? null,
     manuallyDisconnected: true,
     updatedAt: now,
+    selectedWalletId: loadSession(now).selectedWalletId,
   };
   return writeSession(session);
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -110,6 +110,7 @@ export function markConnected(address: string | null, now: number = Date.now()):
     address: address ?? null,
     manuallyDisconnected: false,
     updatedAt: now,
+    selectedWalletId: loadSession(now).selectedWalletId,
   };
   return writeSession(session);
 }


### PR DESCRIPTION
## Title

fix(session, stellar): preserve selectedWalletId on connect/disconnect; add coverage for clearSession and getHorizonServer

## Body

**#543 — markConnected()**: Already implemented, but the rebuilt `WalletSession` object omitted `selectedWalletId`, silently dropping the user's previously chosen wallet module (#459) on every explicit connect. Fixed by reading the current session and carrying the field through.

**#544 — markDisconnected()**: Same `selectedWalletId`-dropping issue as `markConnected`. Fixed identically, plus added regression tests confirming both functions now preserve a persisted `selectedWalletId` across writes.

**#545 — clearSession()**: Already correctly implemented (removes the stored session, swallows privacy-mode `removeItem` failures). Added test coverage for the two previously-untested branches: calling it when nothing is stored, and `removeItem` throwing under privacy-mode storage restrictions.

**#546 — getHorizonServer()**: Already correctly implemented (`new Horizon.Server(HORIZON_URL[network])`). Had no direct test coverage, so added assertions that it targets the right Horizon URL per network and that PUBLIC/TESTNET resolve to distinct endpoints.

Closes #543
Closes #544
Closes #545
Closes #546
