### PR TITLE
Implement service worker registration checks and add session logic test coverage

### DIFF
--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -62,6 +62,25 @@ describe("wallet session persistence (#343)", () => {
     }
   });
 
+  it("loadSession defaults selectedWalletId to null on a fresh session", () => {
+    expect(loadSession(NOW).selectedWalletId).toBeNull();
+  });
+
+  it("loadSession returns a fresh session when the stored record is a JSON array", () => {
+    localStorage.setItem(SESSION_STORAGE_KEY, "[1,2,3]");
+    const session = loadSession(NOW);
+    expect(session.manuallyDisconnected).toBe(false);
+    expect(session.address).toBeNull();
+    // The unparseable-as-a-session record must not be re-parsed on later calls.
+    expect(localStorage.getItem(SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it("loadSession is idempotent: reading twice does not itself expire a fresh record", () => {
+    markDisconnected(ADDRESS, NOW);
+    expect(loadSession(NOW + 1).manuallyDisconnected).toBe(true);
+    expect(loadSession(NOW + 2).manuallyDisconnected).toBe(true);
+  });
+
   it("clearSession removes the record", () => {
     markDisconnected(ADDRESS, NOW);
     clearSession();

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -76,6 +76,20 @@ describe("wallet session persistence (#343)", () => {
     expect(isSessionExpired({ ...session, updatedAt: NaN }, NOW)).toBe(true);
   });
 
+  it("isSessionExpired treats a future-stamped record as not expired in isolation", () => {
+    // loadSession layers its own future-stamp rejection on top of this; in
+    // isolation a negative age is simply "not yet past the TTL".
+    const session = { address: ADDRESS, manuallyDisconnected: true, updatedAt: NOW + 60_000 };
+    expect(isSessionExpired(session, NOW)).toBe(false);
+  });
+
+  it("isSessionExpired defaults `now` to the current time when omitted", () => {
+    const recent = { address: ADDRESS, manuallyDisconnected: true, updatedAt: Date.now() };
+    expect(isSessionExpired(recent)).toBe(false);
+    const stale = { address: ADDRESS, manuallyDisconnected: true, updatedAt: Date.now() - SESSION_TTL_MS - 1 };
+    expect(isSessionExpired(stale)).toBe(true);
+  });
+
   it("markDisconnected returns the written session", () => {
     const result = markDisconnected(ADDRESS, NOW);
     expect(result.manuallyDisconnected).toBe(true);

--- a/src/lib/serviceWorker.ts
+++ b/src/lib/serviceWorker.ts
@@ -128,7 +128,7 @@ interface NavigatorLike {
 
 /** True when this environment can host a worker at all (SSR and older browsers can't). */
 export function isServiceWorkerSupported(nav: NavigatorLike | undefined = typeof navigator === "undefined" ? undefined : navigator): boolean {
-  throw new Error('Not implemented: isServiceWorkerSupported');
+  return typeof nav?.serviceWorker?.register === "function";
 }
 
 /**

--- a/src/lib/serviceWorker.ts
+++ b/src/lib/serviceWorker.ts
@@ -117,7 +117,7 @@ export function isCacheableResponse(response: {
 
 /** Registration is opt-in, so a stale cached shell can never surprise a deploy. */
 export function isServiceWorkerEnabled(): boolean {
-  throw new Error('Not implemented: isServiceWorkerEnabled');
+  return process.env.NEXT_PUBLIC_ENABLE_SW === "true";
 }
 
 interface NavigatorLike {
@@ -140,5 +140,14 @@ export function isServiceWorkerSupported(nav: NavigatorLike | undefined = typeof
 export async function registerServiceWorker(
   nav: NavigatorLike | undefined = typeof navigator === "undefined" ? undefined : navigator,
 ): Promise<ServiceWorkerRegistration | null> {
-  throw new Error('Not implemented: registerServiceWorker');
+  if (!isServiceWorkerEnabled() || !isServiceWorkerSupported(nav)) {
+    return null;
+  }
+  try {
+    return await nav!.serviceWorker!.register(SW_SCRIPT_URL, { scope: SW_SCOPE });
+  } catch {
+    // A failed registration must never break boot: the app is fully
+    // functional without a worker.
+    return null;
+  }
 }


### PR DESCRIPTION
## Title
Implement service worker registration checks and add session logic test coverage

## Body
Implements `isServiceWorkerSupported()` in `src/lib/serviceWorker.ts`: returns true only when `navigator.serviceWorker.register` is a function, so SSR and older browsers safely report unsupported.

Implements `registerServiceWorker()` in `src/lib/serviceWorker.ts`: registers `/sw.js` at the root scope only when the opt-in `NEXT_PUBLIC_ENABLE_SW` flag is on and the environment is supported, swallowing registration failures so a bad registration never breaks app boot. (`isServiceWorkerEnabled()`, which this depends on, was also filled in as it was a stub blocking this function.)

`isSessionExpired()` in `src/lib/session.ts` was already correctly implemented (TTL comparison against `now`). Added edge-case tests: the default `now` parameter, and a future-stamped record evaluated in isolation.

`loadSession()` in `src/lib/session.ts` was already correctly implemented (parses, validates, and expires stored records, falling back to a fresh session). Added tests for the default `selectedWalletId`, a stored record that parses as valid JSON but isn't an object (an array), and idempotence across repeated reads of a non-expired record.

Closes #539
Closes #540
Closes #541
Closes #542
