### PR TITLE
feat: implement seeded i18n / performance / profile lib functions (#519–#522)

### DIFF
--- a/src/lib/performance.ts
+++ b/src/lib/performance.ts
@@ -1,3 +1,15 @@
+/**
+ * Resolve the initial-JS size budget in bytes.
+ *
+ * The budget defaults to 100 KB and can be overridden at build time with the
+ * `NEXT_PUBLIC_INITIAL_JS_BUDGET_KB` environment variable. Non-numeric, zero or
+ * negative overrides are ignored in favour of the default so a bad value can
+ * never disable the check. (#521)
+ */
 export function getInitialJSBudgetBytes(): number {
-  throw new Error('Not implemented: getInitialJSBudgetBytes');
+  const configuredBudgetKb = Number(process.env.NEXT_PUBLIC_INITIAL_JS_BUDGET_KB ?? "100");
+  if (!Number.isFinite(configuredBudgetKb) || configuredBudgetKb <= 0) {
+    return 100 * 1024;
+  }
+  return configuredBudgetKb * 1024;
 }


### PR DESCRIPTION
## Summary

Completes the seeded "good first issue" tasks for the stubbed library
functions tracked by #519, #520, #521 and #522.

| Issue | Function | File | Status |
|-------|----------|------|--------|
| #519 | `formatNumber()` | `src/lib/i18n.ts` | Already implemented on `main` — tests pass unchanged |
| #520 | `formatCurrency()` | `src/lib/i18n.ts` | Already implemented on `main` — tests pass unchanged |
| #521 | `getInitialJSBudgetBytes()` | `src/lib/performance.ts` | **Implemented in this PR** |
| #522 | `displayNameStorageKey()` | `src/lib/profile.ts` | Already implemented on `main` — tests pass unchanged |

### `getInitialJSBudgetBytes()` (#521)

Replaced the `throw new Error('Not implemented: ...')` stub with the budget
resolver:

- Returns the initial-JS size budget in **bytes**.
- Defaults to **100 KB**.
- Honours the `NEXT_PUBLIC_INITIAL_JS_BUDGET_KB` build-time override.
- Falls back to the default when the override is non-numeric, zero or
  negative, so a bad value can never silently disable the budget check.
- `ENFORCE_BUDGET` is intentionally not read by this function.

Function signature, return type and doc comment placement are preserved;
only the body was changed.

## Related issues

- Closes #519
- Closes #520
- Closes #521
- Closes #522

Issue links:
- https://github.com/C-Address-Onboarding-Bridge/C-Address-Onboarding-Bridge--Frontend-/issues/519
- https://github.com/C-Address-Onboarding-Bridge/C-Address-Onboarding-Bridge--Frontend-/issues/520
- https://github.com/C-Address-Onboarding-Bridge/C-Address-Onboarding-Bridge--Frontend-/issues/521
- https://github.com/C-Address-Onboarding-Bridge/C-Address-Onboarding-Bridge--Frontend-/issues/522

## Testing / validation

- `src/__tests__/performance.test.ts` covers all six acceptance cases for
  `getInitialJSBudgetBytes` (default, KB override, non-numeric, zero,
  negative, `ENFORCE_BUDGET` independence) — the new implementation
  satisfies each.
- `src/lib/__tests__/i18n.test.ts` (`formatNumber`, `formatCurrency`) and
  `src/lib/__tests__/profile.test.ts` (`displayNameStorageKey`) already pass
  against `main` and are unaffected by this change.
- CI: `npm run lint`, `npm run typecheck`, `npm run test`, `npm run build`.