### PR TITLE
fix: document getSorobanRpcServer's configuration-error contract

### DIFF
--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -205,6 +205,12 @@ export async function getHorizonServer(network: StellarNetwork): Promise<Horizon
   return new Horizon.Server(HORIZON_URL[network]);
 }
 
+/**
+ * Get a Soroban RPC server client for `network`.
+ *
+ * Throws a descriptive error if no RPC URL is configured for the network
+ * (see `NEXT_PUBLIC_SOROBAN_RPC_URL_<NETWORK>`).
+ */
 export async function getSorobanRpcServer(network: StellarNetwork): Promise<rpc.Server> {
   const url = SOROBAN_RPC_URL[network];
   if (!url) {


### PR DESCRIPTION
## Summary

`getSorobanRpcServer` in `src/lib/stellar.ts` is already implemented (it constructs an `rpc.Server` for the network's configured RPC URL, throwing a descriptive error when none is set) and its tests already pass. What was missing was the doc comment the issue's checklist asks to be kept in place — there wasn't one to keep, so this adds it, describing the return value and the error condition.

## Test plan

- [x] `npx vitest run src/__tests__/stellar-imports.test.ts` — 5/5 pass (covers `getSorobanRpcServer`'s success and error paths)
- Note: this repo is in the "seeded-exercise" state the issue describes — `npm test`/`npm run build` fail repo-wide for reasons unrelated to this file (e.g. real syntax errors in `src/components/wallet-provider.tsx` and `src/app/bridge/page.tsx`, a duplicate declaration in `src/lib/featureFlags.ts`). Per the issue's own "Getting started" note, the full suite isn't expected to be green; the tests naming this function are.

Closes #547