### PR TITLE
fix: document getNetworkPassphrase's return contract

### DIFF
--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -215,6 +215,7 @@ export async function getSorobanRpcServer(network: StellarNetwork): Promise<rpc.
   return new rpc.Server(url);
 }
 
+/** The network passphrase Horizon/Soroban RPC requests for `network` must sign with. */
 export async function getNetworkPassphrase(network: StellarNetwork): Promise<string> {
   return network === "PUBLIC" ? Networks.PUBLIC : Networks.TESTNET;
 }


### PR DESCRIPTION
## Summary

`getNetworkPassphrase` in `src/lib/stellar.ts` is already implemented (it returns `Networks.PUBLIC` or `Networks.TESTNET` based on the given network) and its tests already pass. What was missing was the doc comment the issue's checklist asks to be kept in place — there wasn't one to keep, so this adds it.

## Test plan

- [x] `npx vitest run src/__tests__/stellar-imports.test.ts` — 5/5 pass (covers `getNetworkPassphrase`)
- Note: this repo is in the "seeded-exercise" state the issue describes — `npm test`/`npm run build` fail repo-wide for reasons unrelated to this file (e.g. real syntax errors in `src/components/wallet-provider.tsx` and `src/app/bridge/page.tsx`, a duplicate declaration in `src/lib/featureFlags.ts`). Per the issue's own "Getting started" note, the full suite isn't expected to be green; the tests naming this function are.

Closes #548