### PR TITLE
fix: document isCAddress's validation contract

### DIFF
--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -353,6 +353,7 @@ export function isValidStellarAmount(amount: string): boolean {
   return !isNaN(num) && num > 0;
 }
 
+/** Whether `address` is a valid Soroban contract address (a `C...` StrKey). */
 export function isCAddress(address: string): boolean {
   return StrKey.isValidContract(address);
 }


### PR DESCRIPTION
## Summary

`isCAddress` in `src/lib/stellar.ts` is already implemented (it delegates to `StrKey.isValidContract`, which validates the base32 alphabet and CRC16 checksum of a `C...` address) and its tests already pass. What was missing was the doc comment the issue's checklist asks to be kept in place — there wasn't one to keep, so this adds it.

## Test plan

- [x] `npx vitest run src/__tests__/stellar.test.ts -t isCAddress` — 4/4 pass
- Note: this repo is in the "seeded-exercise" state the issue describes — `npm test`/`npm run build` fail repo-wide for reasons unrelated to this file (e.g. real syntax errors in `src/components/wallet-provider.tsx` and `src/app/bridge/page.tsx`, a duplicate declaration in `src/lib/featureFlags.ts`). Per the issue's own "Getting started" note, the full suite isn't expected to be green; the tests naming this function are.

Closes #562