### PR TITLE
fix: document isGAddress's validation contract

### DIFF
--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -357,6 +357,7 @@ export function isCAddress(address: string): boolean {
   return StrKey.isValidContract(address);
 }
 
+/** Whether `address` is a valid Stellar account address (a `G...` ed25519 StrKey). */
 export function isGAddress(address: string): boolean {
   return StrKey.isValidEd25519PublicKey(address);
 }


### PR DESCRIPTION
## Summary

`isGAddress` in `src/lib/stellar.ts` is already implemented (it delegates to `StrKey.isValidEd25519PublicKey`, which validates the base32 alphabet and CRC16 checksum of a `G...` address) and its tests already pass. What was missing was the doc comment the issue's checklist asks to be kept in place — there wasn't one to keep, so this adds it.

## Test plan

- [x] `npx vitest run src/__tests__/stellar.test.ts -t isGAddress` — 3/3 pass
- Note: this repo is in the "seeded-exercise" state the issue describes — `npm test`/`npm run build` fail repo-wide for reasons unrelated to this file (e.g. real syntax errors in `src/components/wallet-provider.tsx` and `src/app/bridge/page.tsx`, a duplicate declaration in `src/lib/featureFlags.ts`). Per the issue's own "Getting started" note, the full suite isn't expected to be green; the tests naming this function are.

Closes #563