### PR TITLE
fix(stellar): route getWalletAddress/getWalletNetwork through the Stellar Wallets Kit

### DIFF
--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -261,8 +261,13 @@ export async function checkConnection(): Promise<boolean> {
  * Return the public key for the currently connected wallet, or null.
  */
 export async function getWalletAddress(): Promise<string | null> {
+  if (typeof window === "undefined") return null;
   try {
-    const result = await getAddress();
+    if (!_kitReady) {
+      await initWalletKit();
+    }
+    const { StellarWalletsKit } = await import("@creit.tech/stellar-wallets-kit/sdk");
+    const result = await StellarWalletsKit.getAddress();
     return result.address;
   } catch {
     return null;
@@ -294,8 +299,12 @@ export interface WalletNetworkInfo {
  */
 export async function getWalletNetwork(): Promise<WalletNetworkInfo> {
   try {
-    const result = await getNetwork();
-    // Freighter reports failures in-band via `error` as well as by throwing.
+    if (!_kitReady) {
+      await initWalletKit();
+    }
+    const { StellarWalletsKit } = await import("@creit.tech/stellar-wallets-kit/sdk");
+    const result = await StellarWalletsKit.getNetwork();
+    // The wallet can report failures in-band via `error` as well as by throwing.
     if (result && typeof result === "object" && "error" in result && result.error) {
       return { status: "UNKNOWN", name: null };
     }


### PR DESCRIPTION
## Summary

`getWalletAddress`, `getWalletNetwork`, `getCurrentNetwork`, and `formatNetworkLabel` in `src/lib/stellar.ts` were already implemented (no `Not implemented` throw), but `getWalletAddress` and `getWalletNetwork` still called `isConnected`/`getAddress`/`getNetwork` from `@stellar/freighter-api` — an import the #459 multi-wallet migration removed from this file entirely. Every call threw a `ReferenceError`, silently caught and turned into `null` / `"UNKNOWN"`.

Both now go through `StellarWalletsKit.getAddress()` / `StellarWalletsKit.getNetwork()`, lazily initialising the kit first, matching the pattern already used elsewhere in this file (e.g. `openWalletSelectionModal`) and exactly what `walletNetwork.test.ts` already mocks.

- `getCurrentNetwork` needed no change — it only delegates to `getWalletNetwork`.
- `formatNetworkLabel` needed no change — it never touched the wallet API.
- Signatures and doc comments are unchanged on all four functions.

`connectWallet`, `checkConnection`, and `assertActiveAccountMatches` have the same underlying issue (same missing migration) but are separately tracked (#560, #549, #566) and intentionally left untouched here.

Closes #550
Closes #551
Closes #552
Closes #553

## Test plan

- `npx vitest run src/__tests__/walletNetwork.test.ts` — `getCurrentNetwork` (6/6), `getWalletNetwork` (2/2), and `formatNetworkLabel` (3/3) all pass. The only 2 remaining failures in that file are inside `assertActiveAccountMatches`'s own error-message text (issue #566, not touched here).
- Isolated `tsc --noEmit` on `src/lib/stellar.ts` shows no new type errors from this change.
- `eslint src/lib/stellar.ts` — no errors introduced.
- Note: `npm test` (the repo's full suite) and `npm run build` are not green on `main` right now due to unrelated pre-existing breakage (broken JSX in `src/app/bridge/page.tsx`, a syntax error in `src/components/wallet-provider.tsx`, a duplicate export in `src/lib/featureFlags.ts`, and other unimplemented stub functions) — matches this issue's own note that "the full suite will not be green yet."