### PR TITLE
Add on-ramp provider comparison and recurring funding schedules 

### DIFF
--- a/src/__tests__/funding-schedules-page.test.tsx
+++ b/src/__tests__/funding-schedules-page.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { Keypair, StrKey } from "@stellar/stellar-sdk";
+import FundingSchedulesPage from "@/components/routes/funding-schedules-page";
+import { createFundingSchedule } from "@/lib/fundingSchedules";
+
+/**
+ * Unit tests for the Funding Schedules page (#557).
+ *
+ * Covers add/edit/pause/delete through the UI and the "due" banner/actions —
+ * pure storage/calendar/notification rules live in
+ * `src/lib/__tests__/fundingSchedules.test.ts`.
+ */
+
+const C_ADDRESS = StrKey.encodeContract(Keypair.random().rawPublicKey());
+const C_ADDRESS_2 = StrKey.encodeContract(Keypair.random().rawPublicKey());
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+describe("FundingSchedulesPage (#557)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("shows an empty state with no saved schedules", () => {
+    render(<FundingSchedulesPage />);
+    expect(screen.getByText("No recurring schedules yet.")).toBeInTheDocument();
+  });
+
+  it("loads schedules saved before mount", async () => {
+    createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly");
+    render(<FundingSchedulesPage />);
+    expect(await screen.findByText("Rent")).toBeInTheDocument();
+  });
+
+  it("adds a schedule through the form", async () => {
+    render(<FundingSchedulesPage />);
+
+    fireEvent.change(screen.getByTestId("schedule-label-input"), { target: { value: "Rent" } });
+    fireEvent.change(screen.getByTestId("schedule-address-input"), { target: { value: C_ADDRESS } });
+    fireEvent.change(screen.getByTestId("schedule-amount-input"), { target: { value: "100" } });
+    fireEvent.click(screen.getByTestId("add-schedule-button"));
+
+    expect(await screen.findByText("Rent")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule-label-input")).toHaveValue("");
+  });
+
+  it("rejects a G-address and shows why, without saving", async () => {
+    render(<FundingSchedulesPage />);
+    const gAddress = Keypair.random().publicKey();
+
+    fireEvent.change(screen.getByTestId("schedule-label-input"), { target: { value: "Rent" } });
+    fireEvent.change(screen.getByTestId("schedule-address-input"), { target: { value: gAddress } });
+    fireEvent.change(screen.getByTestId("schedule-amount-input"), { target: { value: "100" } });
+    fireEvent.click(screen.getByTestId("add-schedule-button"));
+
+    expect(await screen.findByTestId("add-schedule-error")).toHaveTextContent(/G-address/);
+    expect(screen.queryByText("Rent")).not.toBeInTheDocument();
+  });
+
+  it("edits a schedule in place", async () => {
+    const saved = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+    render(<FundingSchedulesPage />);
+    await screen.findByText("Rent");
+
+    fireEvent.click(screen.getByTestId(`edit-button-${saved.id}`));
+    fireEvent.change(screen.getByTestId(`edit-label-input-${saved.id}`), { target: { value: "Rent Updated" } });
+    fireEvent.change(screen.getByTestId(`edit-address-input-${saved.id}`), { target: { value: C_ADDRESS_2 } });
+    fireEvent.click(screen.getByTestId(`save-edit-${saved.id}`));
+
+    expect(await screen.findByText("Rent Updated")).toBeInTheDocument();
+  });
+
+  it("cancels an edit without saving changes", async () => {
+    createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly");
+    render(<FundingSchedulesPage />);
+    const saved = await screen.findByText("Rent");
+    const row = saved.closest("li")!;
+
+    fireEvent.click(within(row).getByLabelText(/Edit Rent/));
+    const editId = row.querySelector('[data-testid^="edit-label-input-"]')!.getAttribute("data-testid")!.replace("edit-label-input-", "");
+    fireEvent.change(screen.getByTestId(`edit-label-input-${editId}`), { target: { value: "Discarded" } });
+    fireEvent.click(screen.getByTestId(`cancel-edit-${editId}`));
+
+    expect(screen.getByText("Rent")).toBeInTheDocument();
+    expect(screen.queryByText("Discarded")).not.toBeInTheDocument();
+  });
+
+  it("deletes a schedule", async () => {
+    const saved = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+    render(<FundingSchedulesPage />);
+    await screen.findByText("Rent");
+
+    fireEvent.click(screen.getByTestId(`delete-button-${saved.id}`));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Rent")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("No recurring schedules yet.")).toBeInTheDocument();
+  });
+
+  it("pauses and resumes a schedule", async () => {
+    const saved = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+    render(<FundingSchedulesPage />);
+    await screen.findByText("Rent");
+
+    fireEvent.click(screen.getByTestId(`toggle-pause-${saved.id}`));
+    expect(await screen.findByText("(paused)")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId(`toggle-pause-${saved.id}`));
+    await waitFor(() => {
+      expect(screen.queryByText("(paused)")).not.toBeInTheDocument();
+    });
+  });
+
+  it("ignores a corrupted stored entry instead of crashing the page", async () => {
+    const saved = createFundingSchedule("Good", C_ADDRESS, "100", "USDC", "weekly")!;
+    const raw = JSON.parse(window.localStorage.getItem("fundingSchedules:v1")!);
+    window.localStorage.setItem(
+      "fundingSchedules:v1",
+      JSON.stringify([...raw, { ...saved, id: "bad", targetAddress: "not-an-address" }])
+    );
+
+    expect(() => render(<FundingSchedulesPage />)).not.toThrow();
+    expect(await screen.findByText("Good")).toBeInTheDocument();
+  });
+
+  describe("due schedules", () => {
+    it("shows the due banner and 'Mark sent' / 'Open link' actions for an overdue schedule", async () => {
+      const saved = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", Date.now() - WEEK_MS - 1_000)!;
+      render(<FundingSchedulesPage />);
+
+      expect(await screen.findByTestId("due-banner")).toHaveTextContent("Rent");
+      expect(screen.getByTestId(`mark-completed-${saved.id}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`open-link-${saved.id}`)).toBeInTheDocument();
+    });
+
+    it("marking a due schedule as sent removes it from the due banner", async () => {
+      const saved = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", Date.now() - WEEK_MS - 1_000)!;
+      render(<FundingSchedulesPage />);
+      await screen.findByTestId("due-banner");
+
+      fireEvent.click(screen.getByTestId(`mark-completed-${saved.id}`));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("due-banner")).not.toBeInTheDocument();
+      });
+    });
+
+    it("does not show the due banner for a schedule that isn't due yet", () => {
+      createFundingSchedule("Future", C_ADDRESS, "100", "USDC", "weekly", Date.now() + 1_000_000);
+      render(<FundingSchedulesPage />);
+      expect(screen.queryByTestId("due-banner")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/onramp-layout.test.ts
+++ b/src/__tests__/onramp-layout.test.ts
@@ -49,6 +49,14 @@ describe("Payment form layout (#341)", () => {
   });
 
   it("imports only the hooks it uses", () => {
-    expect(source).toContain('import { useState } from "react";');
+    // #556 added the provider quote-comparison panel, which needs
+    // useEffect/useCallback/useRef alongside useState (for its polling
+    // refresh + in-flight-request guard) — this list must stay in sync with
+    // what the file actually imports from "react".
+    expect(source).toContain('import { useState, useEffect, useCallback, useRef } from "react";');
+    const importedHooks = ["useState", "useEffect", "useCallback", "useRef"];
+    for (const hook of importedHooks) {
+      expect(source).toContain(hook);
+    }
   });
 });

--- a/src/__tests__/onramp-quote-comparison.test.tsx
+++ b/src/__tests__/onramp-quote-comparison.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createRoot, Root } from "react-dom/client";
+import OnrampPage from "@/components/routes/onramp-page";
+
+/**
+ * The provider comparison panel (#556) added to the onramp form. Exercised
+ * separately from `onramp-page-buttons.test.tsx` since it needs to control
+ * `fetch` (the panel's best-effort `/api/onramp/quotes` call) and advance
+ * the amount-input debounce timer.
+ */
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("Onramp provider comparison panel", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  const query = <T extends Element>(selector: string) => container.querySelector<T>(selector);
+  const queryAll = <T extends Element>(selector: string) => Array.from(container.querySelectorAll<T>(selector));
+
+  const type = async (el: Element | null, value: string) => {
+    expect(el).not.toBeNull();
+    const input = el as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+    await act(async () => {
+      setter.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  };
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ live: {}, fetchedAt: Date.now() }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<OnrampPage />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  const enterAmount = async (value: string) => {
+    const amountInput = query('input[placeholder="100.00"]');
+    await type(amountInput, value);
+    // useDebounce delays 300ms before the panel's effect (driven by the
+    // debounced amount) picks up the new value.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+  };
+
+  it("is absent until a valid amount is entered", () => {
+    expect(query('[data-testid="quote-comparison-panel"]')).toBeNull();
+  });
+
+  it("ranks moonpay ahead of transak for a plain USD amount, with the local estimate", async () => {
+    await enterAmount("100");
+
+    const panel = query('[data-testid="quote-comparison-panel"]');
+    expect(panel).not.toBeNull();
+    const rows = queryAll('[data-testid^="quote-row-"]');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].getAttribute("data-testid")).toBe("quote-row-moonpay");
+    expect(rows[0].textContent).toContain("95.50");
+    expect(query('[data-testid="quote-spread"]')).not.toBeNull();
+    expect(query('[data-testid="quote-age"]')?.textContent).toContain("Quoted");
+  });
+
+  it("falls back to the local estimate when the live-quote fetch fails (failure isolation)", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    await enterAmount("100");
+
+    const rows = queryAll('[data-testid^="quote-row-"]');
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.textContent?.includes("Estimated"))).toBe(true);
+  });
+
+  it("prefers a live quote over the estimate, and marks it accordingly", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        live: { transak: { sourceAmount: "100", destinationAmount: "99.00", fee: "1.00" } },
+        fetchedAt: Date.now(),
+      }),
+    });
+    await enterAmount("100");
+
+    const transakRow = query('[data-testid="quote-row-transak"]');
+    expect(transakRow?.textContent).toContain("Live");
+    expect(transakRow?.textContent).toContain("99.00");
+    // Transak's live quote now beats moonpay's 95.50 estimate.
+    const rows = queryAll('[data-testid^="quote-row-"]');
+    expect(rows[0].getAttribute("data-testid")).toBe("quote-row-transak");
+  });
+
+  it("shows both providers tied for best when their receive amounts are equal", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        live: { transak: { sourceAmount: "100", destinationAmount: "95.50", fee: "4.50" } },
+        fetchedAt: Date.now(),
+      }),
+    });
+    await enterAmount("100");
+
+    const rows = queryAll('[data-testid^="quote-row-"]');
+    expect(rows).toHaveLength(2);
+    // Both rows get the "best" trophy/styling when tied.
+    for (const row of rows) {
+      expect(row.querySelector(".sr-only")?.textContent).toContain("best rate");
+    }
+  });
+
+  it("clears the panel when the amount is emptied", async () => {
+    await enterAmount("100");
+    expect(query('[data-testid="quote-comparison-panel"]')).not.toBeNull();
+
+    await enterAmount("");
+    expect(query('[data-testid="quote-comparison-panel"]')).toBeNull();
+  });
+});

--- a/src/app/api/onramp/quotes/route.ts
+++ b/src/app/api/onramp/quotes/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { providers } from "@/components/routes/onramp-page";
+import { isOnrampProvider, type OnrampProvider } from "@/lib/types";
+import type { LiveQuoteInput } from "@/lib/onrampQuotes";
+
+/**
+ * Optional live on-ramp quote proxy for #556's provider comparison.
+ *
+ * This repo vendors neither MoonPay's nor Transak's real quote API (their
+ * `providers[].baseUrl` in `onramp-page.tsx` is a checkout *widget* URL, not
+ * a quote endpoint) — the same "not vendored yet" situation `feeTiers.ts` and
+ * `locks.ts` document for their own placeholder integrations. Rather than
+ * guess at request/response shapes for APIs this repo has never called, each
+ * provider's live lookup is gated behind its own env var
+ * (`MOONPAY_QUOTE_API_URL` / `TRANSAK_QUOTE_API_URL`); unset (the default)
+ * means that provider is simply omitted from `live`, and the client falls
+ * back to its own fee-model estimate via `compareOnrampQuotes` — exactly how
+ * `/api/activity` degrades to `[]` when `INDEXER_EVENTS_URL` is unset.
+ *
+ * Each configured provider is queried independently with `Promise.allSettled`
+ * and a per-provider timeout, so one slow or failing provider never blocks or
+ * blanks out the others' quotes (#556's "provider-failure isolation"
+ * requirement) — always resolves 200 with whatever succeeded.
+ */
+
+const QUOTE_TIMEOUT_MS = 5000;
+
+const QUOTE_ENV_URL: Record<OnrampProvider, string | undefined> = {
+  moonpay: process.env.MOONPAY_QUOTE_API_URL,
+  transak: process.env.TRANSAK_QUOTE_API_URL,
+};
+
+function isLiveQuoteShape(value: unknown): value is LiveQuoteInput {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.sourceAmount === "string" &&
+    typeof v.destinationAmount === "string" &&
+    typeof v.fee === "string"
+  );
+}
+
+async function fetchLiveQuote(
+  providerId: OnrampProvider,
+  url: string,
+  amount: string,
+  currency: string
+): Promise<LiveQuoteInput | null> {
+  try {
+    const res = await fetch(`${url}?amount=${encodeURIComponent(amount)}&currency=${encodeURIComponent(currency)}`, {
+      signal: AbortSignal.timeout(QUOTE_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const data: unknown = await res.json();
+    return isLiveQuoteShape(data) ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const amount = searchParams.get("amount");
+  const currency = searchParams.get("currency") ?? "USD";
+
+  if (!amount || !Number.isFinite(Number(amount)) || Number(amount) <= 0) {
+    return NextResponse.json(
+      { error: "A positive numeric `amount` query parameter is required." },
+      { status: 400, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+
+  const configured = providers.filter(
+    (p) => isOnrampProvider(p.id) && QUOTE_ENV_URL[p.id]
+  ) as Array<{ id: OnrampProvider }>;
+
+  const settled = await Promise.allSettled(
+    configured.map((p) => fetchLiveQuote(p.id, QUOTE_ENV_URL[p.id] as string, amount, currency))
+  );
+
+  const live: Partial<Record<OnrampProvider, LiveQuoteInput>> = {};
+  settled.forEach((result, i) => {
+    if (result.status === "fulfilled" && result.value) {
+      live[configured[i].id] = result.value;
+    }
+    // A rejected/failed/timed-out entry is simply absent from `live` — the
+    // caller's compareOnrampQuotes() falls back to the local estimate for it.
+  });
+
+  return NextResponse.json(
+    { live, fetchedAt: Date.now() },
+    { headers: { "Cache-Control": "no-store" } }
+  );
+}

--- a/src/app/schedules/page.tsx
+++ b/src/app/schedules/page.tsx
@@ -1,0 +1,9 @@
+import dynamic from "next/dynamic";
+
+const FundingSchedulesPage = dynamic(() => import("@/components/routes/funding-schedules-page"), {
+  loading: () => <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24 text-sm text-[var(--text-muted)]">Loading schedules…</div>,
+});
+
+export default function SchedulesRoutePage() {
+  return <FundingSchedulesPage />;
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -20,6 +20,7 @@ import {
   LayoutDashboard,
   UserRound,
   BookUser,
+  CalendarClock,
   Menu,
   X,
   AlertTriangle,
@@ -43,7 +44,8 @@ const navLinks = [
   { href: "/onramp", label: "Onramp", icon: CreditCard },
   { href: "/cex", label: "CEX", icon: Building2 },
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/address-book", label: "Address Book", icon: BookUser },
+    { href: "/address-book", label: "Address Book", icon: BookUser },
+  { href: "/schedules", label: "Schedules", icon: CalendarClock },
   { href: "/profile", label: "Profile", icon: UserRound },
 ];
 

--- a/src/components/routes/funding-schedules-page.tsx
+++ b/src/components/routes/funding-schedules-page.tsx
@@ -1,0 +1,459 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CalendarClock, ExternalLink, Pause, Pencil, Play, Plus, Trash2, X } from "lucide-react";
+import { truncateAddress } from "@/components/AddressForm";
+import LiveRegion from "@/components/live-region";
+import {
+  FUNDING_FREQUENCIES,
+  SCHEDULE_LABEL_MAX_LENGTH,
+  buildScheduleFundingLink,
+  checkAndNotifyDueSchedules,
+  createFundingSchedule,
+  deleteFundingSchedule,
+  dueSchedules,
+  formatFrequency,
+  loadFundingSchedules,
+  markScheduleCompleted,
+  pauseFundingSchedule,
+  resumeFundingSchedule,
+  updateFundingSchedule,
+  validateFundingSchedule,
+  type FundingSchedule,
+} from "@/lib/fundingSchedules";
+import { FUNDING_LINK_ASSETS } from "@/lib/fundingLink";
+import { ROUTES } from "@/lib/routes";
+
+/**
+ * Recurring funding schedules page (#557).
+ *
+ * Lets the user save a recurring "fund this C-address" reminder. There is no
+ * backend and nothing here executes automatically (see `fundingSchedules.ts`'s
+ * module docs) — a due schedule surfaces in the notification centre and,
+ * from this page, opens a pre-filled bridge link so completing it is a click
+ * plus a signature, not a re-typed address. Not wallet-gated, same reasoning
+ * as the address book: the store isn't keyed to the connected wallet.
+ */
+export default function FundingSchedulesPage() {
+  const [schedules, setSchedules] = useState<FundingSchedule[]>([]);
+
+  const [newLabel, setNewLabel] = useState("");
+  const [newAddress, setNewAddress] = useState("");
+  const [newAmount, setNewAmount] = useState("");
+  const [newAsset, setNewAsset] = useState<string>(FUNDING_LINK_ASSETS[0]);
+  const [newFrequency, setNewFrequency] = useState<string>(FUNDING_FREQUENCIES[0]);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editLabel, setEditLabel] = useState("");
+  const [editAddress, setEditAddress] = useState("");
+  const [editAmount, setEditAmount] = useState("");
+  const [editAsset, setEditAsset] = useState<string>(FUNDING_LINK_ASSETS[0]);
+  const [editFrequency, setEditFrequency] = useState<string>(FUNDING_FREQUENCIES[0]);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const [notice, setNotice] = useState("");
+
+  // Read from storage (and check for due schedules) after mount only —
+  // touching localStorage during render would break hydration, same guard
+  // AddressBookPage uses for its own store.
+  useEffect(() => {
+    checkAndNotifyDueSchedules();
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSchedules(loadFundingSchedules());
+  }, []);
+
+  const refresh = () => setSchedules(loadFundingSchedules());
+
+  const handleAdd = (event: React.FormEvent) => {
+    event.preventDefault();
+    const validation = validateFundingSchedule(newLabel, newAddress, newAmount, newAsset, newFrequency);
+    if (!validation.ok) {
+      setAddError(validation.error);
+      setNotice("");
+      return;
+    }
+    const created = createFundingSchedule(newLabel, newAddress, newAmount, newAsset, newFrequency);
+    if (!created) {
+      setAddError("Couldn't save — you may have reached the schedule limit, or browser storage is full.");
+      setNotice("");
+      return;
+    }
+    setAddError(null);
+    setNewLabel("");
+    setNewAddress("");
+    setNewAmount("");
+    refresh();
+    setNotice(`Saved "${created.label}".`);
+  };
+
+  const startEdit = (schedule: FundingSchedule) => {
+    setEditingId(schedule.id);
+    setEditLabel(schedule.label);
+    setEditAddress(schedule.targetAddress);
+    setEditAmount(schedule.amount);
+    setEditAsset(schedule.asset);
+    setEditFrequency(schedule.frequency);
+    setEditError(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditError(null);
+  };
+
+  const handleSaveEdit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!editingId) return;
+
+    const validation = validateFundingSchedule(editLabel, editAddress, editAmount, editAsset, editFrequency);
+    if (!validation.ok) {
+      setEditError(validation.error);
+      return;
+    }
+    if (!updateFundingSchedule(editingId, editLabel, editAddress, editAmount, editAsset, editFrequency)) {
+      setEditError("Couldn't save — browser storage may be full.");
+      return;
+    }
+    setEditingId(null);
+    setEditError(null);
+    refresh();
+    setNotice(`Updated "${validation.label}".`);
+  };
+
+  const handleDelete = (schedule: FundingSchedule) => {
+    deleteFundingSchedule(schedule.id);
+    if (editingId === schedule.id) setEditingId(null);
+    refresh();
+    setNotice(`Removed "${schedule.label}".`);
+  };
+
+  const handleTogglePause = (schedule: FundingSchedule) => {
+    if (schedule.paused) {
+      resumeFundingSchedule(schedule.id);
+      setNotice(`Resumed "${schedule.label}".`);
+    } else {
+      pauseFundingSchedule(schedule.id);
+      setNotice(`Paused "${schedule.label}".`);
+    }
+    refresh();
+  };
+
+  const handleMarkCompleted = (schedule: FundingSchedule) => {
+    markScheduleCompleted(schedule.id);
+    refresh();
+    setNotice(`Marked "${schedule.label}" as sent. Next due: one ${schedule.frequency.replace("ly", "")} from now.`);
+  };
+
+  const openFundingLink = (schedule: FundingSchedule) => {
+    const baseUrl = `${window.location.origin}${ROUTES.BRIDGE}`;
+    const link = buildScheduleFundingLink(baseUrl, schedule);
+    window.open(link, "_blank", "noopener,noreferrer");
+  };
+
+  const due = dueSchedules(schedules);
+  const dueIds = new Set(due.map((s) => s.id));
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">Recurring Funding Schedules</h1>
+        <p className="text-[var(--text-muted)]">
+          Set reminders to fund a C-address on a schedule. Stored in this browser only — nothing here sends
+          funds automatically; a due schedule opens a pre-filled bridge link for you to complete and sign.
+        </p>
+      </div>
+
+      {due.length > 0 && (
+        <div
+          role="status"
+          data-testid="due-banner"
+          className="mb-6 p-4 rounded-lg bg-[var(--primary)]/10 border border-[var(--primary)]/20 flex items-center gap-3"
+        >
+          <CalendarClock className="w-5 h-5 text-[var(--primary)] flex-shrink-0" />
+          <p className="text-sm">
+            {due.length} schedule{due.length === 1 ? "" : "s"} due: {due.map((s) => s.label).join(", ")}.
+          </p>
+        </div>
+      )}
+
+      <section aria-labelledby="schedule-add" className="card p-6 mb-6">
+        <h2 id="schedule-add" className="text-lg font-semibold mb-4">
+          New Schedule
+        </h2>
+        <form onSubmit={handleAdd} noValidate className="space-y-4">
+          <div>
+            <label htmlFor="schedule-label" className="block text-sm font-medium mb-1.5">
+              Label
+            </label>
+            <input
+              id="schedule-label"
+              type="text"
+              value={newLabel}
+              onChange={(e) => {
+                setNewLabel(e.target.value);
+                setAddError(null);
+              }}
+              maxLength={SCHEDULE_LABEL_MAX_LENGTH * 2}
+              placeholder="e.g. Monthly savings top-up"
+              data-testid="schedule-label-input"
+              className="w-full px-4 py-2.5 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors"
+            />
+          </div>
+          <div>
+            <label htmlFor="schedule-address" className="block text-sm font-medium mb-1.5">
+              Target C-Address
+            </label>
+            <input
+              id="schedule-address"
+              type="text"
+              value={newAddress}
+              onChange={(e) => {
+                setNewAddress(e.target.value);
+                setAddError(null);
+              }}
+              placeholder="C..."
+              data-testid="schedule-address-input"
+              className="w-full px-4 py-2.5 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm font-mono focus:outline-none focus:border-[var(--primary)] transition-colors"
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div>
+              <label htmlFor="schedule-amount" className="block text-sm font-medium mb-1.5">
+                Amount
+              </label>
+              <input
+                id="schedule-amount"
+                type="text"
+                value={newAmount}
+                onChange={(e) => {
+                  setNewAmount(e.target.value);
+                  setAddError(null);
+                }}
+                placeholder="100"
+                data-testid="schedule-amount-input"
+                className="w-full px-4 py-2.5 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors"
+              />
+            </div>
+            <div>
+              <label htmlFor="schedule-asset" className="block text-sm font-medium mb-1.5">
+                Asset
+              </label>
+              <select
+                id="schedule-asset"
+                value={newAsset}
+                onChange={(e) => setNewAsset(e.target.value)}
+                data-testid="schedule-asset-select"
+                className="w-full px-4 py-2.5 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors"
+              >
+                {FUNDING_LINK_ASSETS.map((asset) => (
+                  <option key={asset} value={asset}>
+                    {asset}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="schedule-frequency" className="block text-sm font-medium mb-1.5">
+                Frequency
+              </label>
+              <select
+                id="schedule-frequency"
+                value={newFrequency}
+                onChange={(e) => setNewFrequency(e.target.value)}
+                data-testid="schedule-frequency-select"
+                className="w-full px-4 py-2.5 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors"
+              >
+                {FUNDING_FREQUENCIES.map((freq) => (
+                  <option key={freq} value={freq}>
+                    {formatFrequency(freq)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          {addError && (
+            <p role="alert" data-testid="add-schedule-error" className="text-xs text-[var(--error)]">
+              {addError}
+            </p>
+          )}
+          <button
+            type="submit"
+            data-testid="add-schedule-button"
+            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-[var(--primary)] text-white text-sm font-medium hover:bg-[var(--primary)]/90 transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            Save Schedule
+          </button>
+        </form>
+      </section>
+
+      <section aria-labelledby="schedule-list" className="card p-6 mb-6">
+        <h2 id="schedule-list" className="text-lg font-semibold mb-4">
+          Saved Schedules ({schedules.length})
+        </h2>
+
+        {schedules.length === 0 ? (
+          <p className="text-sm text-[var(--text-muted)]">No recurring schedules yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {schedules.map((schedule) =>
+              editingId === schedule.id ? (
+                <li key={schedule.id} className="p-3 rounded-lg bg-[var(--surface-2)]">
+                  <form onSubmit={handleSaveEdit} className="space-y-2">
+                    <input
+                      type="text"
+                      value={editLabel}
+                      onChange={(e) => setEditLabel(e.target.value)}
+                      data-testid={`edit-label-input-${schedule.id}`}
+                      className="w-full px-3 py-2 rounded-lg bg-[var(--surface)] border border-[var(--border)] text-sm"
+                    />
+                    <input
+                      type="text"
+                      value={editAddress}
+                      onChange={(e) => setEditAddress(e.target.value)}
+                      data-testid={`edit-address-input-${schedule.id}`}
+                      className="w-full px-3 py-2 rounded-lg bg-[var(--surface)] border border-[var(--border)] text-sm font-mono"
+                    />
+                    <div className="grid grid-cols-3 gap-2">
+                      <input
+                        type="text"
+                        value={editAmount}
+                        onChange={(e) => setEditAmount(e.target.value)}
+                        data-testid={`edit-amount-input-${schedule.id}`}
+                        className="w-full px-3 py-2 rounded-lg bg-[var(--surface)] border border-[var(--border)] text-sm"
+                      />
+                      <select
+                        value={editAsset}
+                        onChange={(e) => setEditAsset(e.target.value)}
+                        data-testid={`edit-asset-select-${schedule.id}`}
+                        className="w-full px-3 py-2 rounded-lg bg-[var(--surface)] border border-[var(--border)] text-sm"
+                      >
+                        {FUNDING_LINK_ASSETS.map((asset) => (
+                          <option key={asset} value={asset}>
+                            {asset}
+                          </option>
+                        ))}
+                      </select>
+                      <select
+                        value={editFrequency}
+                        onChange={(e) => setEditFrequency(e.target.value)}
+                        data-testid={`edit-frequency-select-${schedule.id}`}
+                        className="w-full px-3 py-2 rounded-lg bg-[var(--surface)] border border-[var(--border)] text-sm"
+                      >
+                        {FUNDING_FREQUENCIES.map((freq) => (
+                          <option key={freq} value={freq}>
+                            {formatFrequency(freq)}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    {editError && (
+                      <p role="alert" data-testid="edit-schedule-error" className="text-xs text-[var(--error)]">
+                        {editError}
+                      </p>
+                    )}
+                    <div className="flex gap-2">
+                      <button
+                        type="submit"
+                        data-testid={`save-edit-${schedule.id}`}
+                        className="px-3 py-1.5 rounded-lg bg-[var(--primary)] text-white text-xs font-medium"
+                      >
+                        Save
+                      </button>
+                      <button
+                        type="button"
+                        onClick={cancelEdit}
+                        data-testid={`cancel-edit-${schedule.id}`}
+                        className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-[var(--border)] text-xs font-medium"
+                      >
+                        <X className="w-3 h-3" />
+                        Cancel
+                      </button>
+                    </div>
+                  </form>
+                </li>
+              ) : (
+                <li
+                  key={schedule.id}
+                  data-testid={`schedule-row-${schedule.id}`}
+                  className={`p-3 rounded-lg border ${
+                    dueIds.has(schedule.id)
+                      ? "border-[var(--primary)] bg-[var(--primary)]/5"
+                      : "border-transparent bg-[var(--surface-2)]"
+                  } ${schedule.paused ? "opacity-60" : ""}`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        {schedule.label}
+                        {schedule.paused && <span className="ml-2 text-xs text-[var(--text-muted)]">(paused)</span>}
+                      </p>
+                      <p className="text-xs font-mono text-[var(--text-muted)]">{truncateAddress(schedule.targetAddress)}</p>
+                      <p className="text-xs text-[var(--text-muted)] mt-0.5">
+                        {schedule.amount} {schedule.asset} · {formatFrequency(schedule.frequency)} · Next:{" "}
+                        {new Date(schedule.nextRunAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <div className="flex gap-1 shrink-0">
+                      {dueIds.has(schedule.id) && (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => openFundingLink(schedule)}
+                            aria-label={`Open funding link for ${schedule.label}`}
+                            data-testid={`open-link-${schedule.id}`}
+                            className="p-1.5 rounded hover:bg-[var(--surface)] text-[var(--primary)] transition-colors"
+                          >
+                            <ExternalLink className="w-3.5 h-3.5" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleMarkCompleted(schedule)}
+                            data-testid={`mark-completed-${schedule.id}`}
+                            className="px-2 py-1 rounded text-xs font-medium border border-[var(--primary)] text-[var(--primary)] hover:bg-[var(--primary)]/10 transition-colors"
+                          >
+                            Mark sent
+                          </button>
+                        </>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => handleTogglePause(schedule)}
+                        aria-label={schedule.paused ? `Resume ${schedule.label}` : `Pause ${schedule.label}`}
+                        data-testid={`toggle-pause-${schedule.id}`}
+                        className="p-1.5 rounded hover:bg-[var(--surface)] text-[var(--text-muted)] hover:text-[var(--foreground)] transition-colors"
+                      >
+                        {schedule.paused ? <Play className="w-3.5 h-3.5" /> : <Pause className="w-3.5 h-3.5" />}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => startEdit(schedule)}
+                        aria-label={`Edit ${schedule.label}`}
+                        data-testid={`edit-button-${schedule.id}`}
+                        className="p-1.5 rounded hover:bg-[var(--surface)] text-[var(--text-muted)] hover:text-[var(--foreground)] transition-colors"
+                      >
+                        <Pencil className="w-3.5 h-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(schedule)}
+                        aria-label={`Delete ${schedule.label}`}
+                        data-testid={`delete-button-${schedule.id}`}
+                        className="p-1.5 rounded hover:bg-[var(--surface)] text-[var(--text-muted)] hover:text-[var(--error)] transition-colors"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              )
+            )}
+          </ul>
+        )}
+      </section>
+
+      <LiveRegion message={notice} />
+    </div>
+  );
+}

--- a/src/components/routes/onramp-page.tsx
+++ b/src/components/routes/onramp-page.tsx
@@ -1,16 +1,28 @@
 "use client";
 
-import { useState } from "react";
-import { CreditCard, Wallet, ExternalLink, ArrowRight, Check, DollarSign, AlertCircle, HelpCircle } from "lucide-react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { CreditCard, Wallet, ExternalLink, ArrowRight, Check, DollarSign, AlertCircle, HelpCircle, RefreshCw, Trophy } from "lucide-react";
 import LiveRegion from "@/components/live-region";
 import { isValidStellarAddress, isCAddress } from "@/lib/stellar";
+import {
+  compareOnrampQuotes,
+  quoteSpread,
+  formatQuoteAge,
+  formatQuoteFeeRate,
+  type OnrampQuoteComparison,
+} from "@/lib/onrampQuotes";
+import type { OnrampProvider } from "@/lib/types";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useHelp } from "@/contexts/HelpContext";
 
 const MOONPAY_API_KEY = process.env.NEXT_PUBLIC_MOONPAY_API_KEY || "";
 const TRANSAK_API_KEY = process.env.NEXT_PUBLIC_TRANSAK_API_KEY || "";
 
-const providers = [
+// Exported (in addition to the pure helpers below) so `src/lib/onrampQuotes.ts`
+// (#556) can compare providers without re-declaring this list — one source of
+// truth for id/name/fee/limits/currencies, same reasoning as exporting
+// getProviderFeeRate/calculateOnrampFeeAndReceive themselves.
+export const providers = [
   {
     id: "moonpay",
     name: "Moonpay",
@@ -95,6 +107,161 @@ export function buildProviderUrl(p: typeof providers[number], cAddress: string, 
           fiatCurrency: fiatCurrency,
         });
   return `${p.baseUrl}?${params}`;
+}
+
+const QUOTE_REFRESH_INTERVAL_MS = 30_000;
+
+/**
+ * Side-by-side provider comparison (#556). Purely additive to the existing
+ * form — `getProviderFeeRate`/`calculateOnrampFeeAndReceive` above still
+ * drive the single-provider "Estimated Output" box; this ranks all
+ * supported providers against each other for the same amount/currency.
+ *
+ * Live quotes are best-effort: `/api/onramp/quotes` degrades to `{ live: {} }`
+ * when no provider has a live-quote URL configured (see that route's docs),
+ * and a request that fails outright (network error, non-2xx, bad JSON) is
+ * treated the same way — `compareOnrampQuotes` always has its own estimate
+ * to fall back on, so a fetch failure never blanks the panel.
+ */
+function QuoteComparisonPanel({
+  fiatAmount,
+  fiatCurrency,
+  isValid,
+}: {
+  fiatAmount: string;
+  fiatCurrency: string;
+  isValid: boolean;
+}) {
+  const [comparisons, setComparisons] = useState<OnrampQuoteComparison[]>([]);
+  const [quotedAt, setQuotedAt] = useState<number | null>(null);
+  const [, forceTick] = useState(0);
+  const requestIdRef = useRef(0);
+
+  const amount = Number(fiatAmount) || 0;
+
+  const refresh = useCallback(async () => {
+    if (!isValid || amount <= 0) {
+      setComparisons([]);
+      setQuotedAt(null);
+      return;
+    }
+    const requestId = ++requestIdRef.current;
+    // Local estimate first, synchronously, so the panel never shows nothing
+    // while the (optional) live fetch is in flight.
+    setComparisons(compareOnrampQuotes(amount, fiatCurrency));
+    setQuotedAt(Date.now());
+
+    try {
+      const res = await fetch(`/api/onramp/quotes?amount=${encodeURIComponent(String(amount))}&currency=${encodeURIComponent(fiatCurrency)}`);
+      if (!res.ok) return;
+      const data: unknown = await res.json();
+      // A slower response for a superseded amount/currency must not clobber
+      // a newer one that already resolved.
+      if (requestId !== requestIdRef.current) return;
+      const live = (data as { live?: Partial<Record<OnrampProvider, { sourceAmount: string; destinationAmount: string; fee: string }>> }).live ?? {};
+      setComparisons(compareOnrampQuotes(amount, fiatCurrency, { liveQuotes: live }));
+      setQuotedAt(Date.now());
+    } catch {
+      // Network failure: the local-estimate comparison set above stands.
+    }
+  }, [amount, fiatCurrency, isValid]);
+
+  useEffect(() => {
+    // Fetch-on-mount/-change, same justified pattern as AddressBookPage's
+    // load effect: synchronizing the panel with the external quote source
+    // (the local estimator + /api/onramp/quotes) whenever amount/currency
+    // change, not deriving state from a render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    refresh();
+  }, [refresh]);
+
+  // Timed refresh while a valid amount is entered, plus a 1s tick so the
+  // "quoted Xs ago" age display stays live between refreshes.
+  useEffect(() => {
+    if (!isValid || amount <= 0) return;
+    const refreshTimer = setInterval(refresh, QUOTE_REFRESH_INTERVAL_MS);
+    const tickTimer = setInterval(() => forceTick((n) => n + 1), 1000);
+    return () => {
+      clearInterval(refreshTimer);
+      clearInterval(tickTimer);
+    };
+  }, [refresh, isValid, amount]);
+
+  if (!isValid || amount <= 0) return null;
+
+  const spread = quoteSpread(comparisons);
+
+  return (
+    <div className="card p-5" data-testid="quote-comparison-panel">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="font-semibold">Compare Providers</h3>
+        <button
+          type="button"
+          onClick={refresh}
+          aria-label="Refresh quotes"
+          data-testid="quote-refresh-button"
+          className="p-1.5 rounded hover:bg-[var(--surface-2)] text-[var(--text-muted)] transition-colors"
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {comparisons.length === 0 ? (
+        <p className="text-sm text-[var(--text-muted)]">
+          No provider currently supports {fiatCurrency} for this comparison.
+        </p>
+      ) : (
+        <>
+          <ul className="space-y-2" data-testid="quote-comparison-list">
+            {comparisons.map((q) => (
+              <li
+                key={q.provider}
+                data-testid={`quote-row-${q.provider}`}
+                className={`p-3 rounded-lg border ${
+                  q.isBest ? "border-[var(--primary)] bg-[var(--primary)]/5" : "border-[var(--border)] bg-[var(--surface-2)]"
+                }`}
+              >
+                <div className="flex items-center justify-between gap-2 mb-1">
+                  <span className="text-sm font-medium flex items-center gap-1.5">
+                    {q.isBest && <Trophy className="w-3.5 h-3.5 text-[var(--primary)]" aria-hidden="true" />}
+                    {q.providerName}
+                    {q.isBest && <span className="sr-only"> — best rate</span>}
+                  </span>
+                  <span className="text-xs text-[var(--text-muted)]">
+                    {q.source === "live" ? "Live" : "Estimated"}
+                  </span>
+                </div>
+                <div className="flex justify-between text-xs text-[var(--text-muted)]">
+                  <span>Rate ({formatQuoteFeeRate(q.provider)} fee)</span>
+                  <span className="tabular-nums">-{q.fee} {q.fiatCurrency}</span>
+                </div>
+                <div className="flex justify-between text-sm font-semibold mt-1">
+                  <span className="text-[var(--text-muted)] font-normal text-xs self-center">You receive</span>
+                  <span className="tabular-nums">{q.destinationAmount} USDC</span>
+                </div>
+                {q.withinLimits === false && (
+                  <p className="text-xs text-[var(--error)] mt-1" role="alert">
+                    Outside {q.providerName}&apos;s advertised limits for this amount.
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          {spread && (
+            <p className="text-xs text-[var(--text-muted)] mt-3" data-testid="quote-spread">
+              Best vs. worst: {spread.absolute.toFixed(2)} USDC ({spread.percent.toFixed(1)}%) apart.
+            </p>
+          )}
+          {quotedAt && (
+            <p className="text-xs text-[var(--text-muted)] mt-1" data-testid="quote-age">
+              Quoted {formatQuoteAge(quotedAt)}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
 }
 
 export default function OnrampPage() {
@@ -366,6 +533,12 @@ export default function OnrampPage() {
         </div>
 
         <div className="space-y-4">
+          <QuoteComparisonPanel
+            fiatAmount={debouncedFiatAmount}
+            fiatCurrency={fiatCurrency}
+            isValid={validAmount && debouncedFiatAmount === fiatAmount}
+          />
+
           <div className="card p-5">
             <h3 className="font-semibold mb-3">Supported Providers</h3>
             <div className="space-y-3">

--- a/src/lib/__tests__/fundingSchedules.ssr.test.ts
+++ b/src/lib/__tests__/fundingSchedules.ssr.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Keypair, StrKey } from "@stellar/stellar-sdk";
+import { loadNotifications } from "../notifications";
+import {
+  FUNDING_FREQUENCIES,
+  MAX_FUNDING_SCHEDULES,
+  SCHEDULE_LABEL_MAX_LENGTH,
+  buildScheduleFundingLink,
+  checkAndNotifyDueSchedules,
+  computeNextRunAt,
+  createFundingSchedule,
+  deleteFundingSchedule,
+  dueSchedules,
+  formatFrequency,
+  isFundingFrequency,
+  isRenderableSchedule,
+  isScheduleDue,
+  loadFundingSchedules,
+  markScheduleCompleted,
+  pauseFundingSchedule,
+  resumeFundingSchedule,
+  updateFundingSchedule,
+  validateFundingSchedule,
+} from "../fundingSchedules";
+
+/**
+ * Unit tests for the recurring funding schedule store (#557). Structured
+ * like `addressBook.test.ts`: interesting cases are untrusted-storage shapes
+ * and the calendar/notification edge cases specific to "due on a recurring
+ * cadence". SSR behaviour is covered separately in
+ * `fundingSchedules.ssr.test.ts`.
+ */
+
+const C_ADDRESS = StrKey.encodeContract(Keypair.random().rawPublicKey());
+const C_ADDRESS_2 = StrKey.encodeContract(Keypair.random().rawPublicKey());
+const G_ADDRESS = Keypair.random().publicKey();
+
+describe("recurring funding schedules (#557)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe("validateFundingSchedule", () => {
+    it("accepts a well-formed schedule", () => {
+      const result = validateFundingSchedule(" Rent ", C_ADDRESS, "100", "USDC", "monthly");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.label).toBe("Rent"); // trimmed
+        expect(result.targetAddress).toBe(C_ADDRESS);
+      }
+    });
+
+    it("rejects an empty label", () => {
+      const result = validateFundingSchedule("   ", C_ADDRESS, "100", "USDC", "monthly");
+      expect(result).toEqual({ ok: false, error: "Label is required" });
+    });
+
+    it("rejects a label over the length budget", () => {
+      const result = validateFundingSchedule("x".repeat(SCHEDULE_LABEL_MAX_LENGTH + 1), C_ADDRESS, "100", "USDC", "monthly");
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects a G-address (must be a C-address, mirroring batch funding)", () => {
+      const result = validateFundingSchedule("Rent", G_ADDRESS, "100", "USDC", "monthly");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("G-address");
+    });
+
+    it("rejects an invalid amount", () => {
+      const result = validateFundingSchedule("Rent", C_ADDRESS, "-5", "USDC", "monthly");
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects an unsupported asset", () => {
+      const result = validateFundingSchedule("Rent", C_ADDRESS, "100", "BTC", "monthly");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("Unsupported asset");
+    });
+
+    it("rejects an unsupported frequency", () => {
+      const result = validateFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "daily");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("Unsupported frequency");
+    });
+  });
+
+  describe("computeNextRunAt", () => {
+    it("advances weekly by exactly 7 days", () => {
+      const from = Date.UTC(2026, 0, 1); // Jan 1, 2026
+      expect(computeNextRunAt("weekly", from)).toBe(from + 7 * 24 * 60 * 60 * 1000);
+    });
+
+    it("advances biweekly by exactly 14 days", () => {
+      const from = Date.UTC(2026, 0, 1);
+      expect(computeNextRunAt("biweekly", from)).toBe(from + 14 * 24 * 60 * 60 * 1000);
+    });
+
+    it("advances monthly to the same day next month in the common case", () => {
+      const from = Date.UTC(2026, 0, 15); // Jan 15, 2026
+      const next = new Date(computeNextRunAt("monthly", from));
+      expect(next.getUTCFullYear()).toBe(2026);
+      expect(next.getUTCMonth()).toBe(1); // February
+      expect(next.getUTCDate()).toBe(15);
+    });
+
+    it("clamps a month-end date instead of overflowing into the following month", () => {
+      const from = Date.UTC(2026, 0, 31); // Jan 31, 2026
+      const next = new Date(computeNextRunAt("monthly", from));
+      // Feb 2026 has 28 days — must clamp to Feb 28, not spill into March.
+      expect(next.getUTCMonth()).toBe(1);
+      expect(next.getUTCDate()).toBe(28);
+    });
+
+    it("handles a December -> January year rollover", () => {
+      const from = Date.UTC(2026, 11, 15); // Dec 15, 2026
+      const next = new Date(computeNextRunAt("monthly", from));
+      expect(next.getUTCFullYear()).toBe(2027);
+      expect(next.getUTCMonth()).toBe(0);
+      expect(next.getUTCDate()).toBe(15);
+    });
+  });
+
+  describe("createFundingSchedule / loadFundingSchedules", () => {
+    it("creates a schedule with nextRunAt one period ahead of startAt", () => {
+      const startAt = Date.UTC(2026, 0, 1);
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", startAt);
+      expect(schedule).not.toBeNull();
+      expect(schedule!.nextRunAt).toBe(computeNextRunAt("weekly", startAt));
+      expect(schedule!.paused).toBe(false);
+      expect(loadFundingSchedules()).toHaveLength(1);
+    });
+
+    it("returns null and saves nothing for invalid input", () => {
+      expect(createFundingSchedule("", C_ADDRESS, "100", "USDC", "weekly")).toBeNull();
+      expect(loadFundingSchedules()).toHaveLength(0);
+    });
+
+    it("enforces the MAX_FUNDING_SCHEDULES cap", () => {
+      for (let i = 0; i < MAX_FUNDING_SCHEDULES; i++) {
+        expect(createFundingSchedule(`Sched ${i}`, C_ADDRESS, "10", "USDC", "weekly")).not.toBeNull();
+      }
+      expect(loadFundingSchedules()).toHaveLength(MAX_FUNDING_SCHEDULES);
+      expect(createFundingSchedule("One too many", C_ADDRESS, "10", "USDC", "weekly")).toBeNull();
+      expect(loadFundingSchedules()).toHaveLength(MAX_FUNDING_SCHEDULES);
+    });
+  });
+
+  describe("isRenderableSchedule", () => {
+    it("drops entries with an invalid target address (e.g. hand-edited storage)", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly");
+      window.localStorage.setItem(
+        "fundingSchedules:v1",
+        JSON.stringify([{ ...schedule, targetAddress: "not-an-address" }])
+      );
+      expect(loadFundingSchedules()).toHaveLength(0);
+    });
+
+    it("drops entries with an unknown frequency", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly");
+      window.localStorage.setItem(
+        "fundingSchedules:v1",
+        JSON.stringify([{ ...schedule, frequency: "yearly" }])
+      );
+      expect(loadFundingSchedules()).toHaveLength(0);
+    });
+
+    it("is fine with a non-object entry rejected outright", () => {
+      expect(isRenderableSchedule("nope")).toBe(false);
+      expect(isRenderableSchedule(null)).toBe(false);
+    });
+  });
+
+  describe("updateFundingSchedule", () => {
+    it("updates fields and recomputes nextRunAt when frequency changes", () => {
+      const startAt = Date.UTC(2026, 0, 1);
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", startAt)!;
+      const originalNextRunAt = schedule.nextRunAt;
+
+      const ok = updateFundingSchedule(schedule.id, "Rent (updated)", C_ADDRESS_2, "150", "XLM", "monthly");
+      expect(ok).toBe(true);
+
+      const [updated] = loadFundingSchedules();
+      expect(updated.label).toBe("Rent (updated)");
+      expect(updated.targetAddress).toBe(C_ADDRESS_2);
+      expect(updated.amount).toBe("150");
+      expect(updated.asset).toBe("XLM");
+      expect(updated.frequency).toBe("monthly");
+      expect(updated.nextRunAt).not.toBe(originalNextRunAt);
+    });
+
+    it("leaves nextRunAt untouched when frequency doesn't change", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+      updateFundingSchedule(schedule.id, "Rent v2", C_ADDRESS, "200", "USDC", "weekly");
+      const [updated] = loadFundingSchedules();
+      expect(updated.nextRunAt).toBe(schedule.nextRunAt);
+    });
+
+    it("returns false for an unknown id", () => {
+      expect(updateFundingSchedule("nope", "Rent", C_ADDRESS, "100", "USDC", "weekly")).toBe(false);
+    });
+
+    it("returns false and leaves storage untouched for invalid input", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+      expect(updateFundingSchedule(schedule.id, "", C_ADDRESS, "100", "USDC", "weekly")).toBe(false);
+      expect(loadFundingSchedules()[0].label).toBe("Rent");
+    });
+  });
+
+  describe("deleteFundingSchedule", () => {
+    it("removes the schedule and returns true", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+      expect(deleteFundingSchedule(schedule.id)).toBe(true);
+      expect(loadFundingSchedules()).toHaveLength(0);
+    });
+
+    it("returns false for an id that doesn't exist", () => {
+      expect(deleteFundingSchedule("nope")).toBe(false);
+    });
+  });
+
+  describe("pauseFundingSchedule / resumeFundingSchedule", () => {
+    it("pausing excludes a due schedule from isScheduleDue", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", 0)!;
+      expect(isScheduleDue(schedule, Date.now())).toBe(true);
+
+      pauseFundingSchedule(schedule.id);
+      const [paused] = loadFundingSchedules();
+      expect(isScheduleDue(paused, Date.now())).toBe(false);
+
+      resumeFundingSchedule(schedule.id);
+      const [resumed] = loadFundingSchedules();
+      expect(isScheduleDue(resumed, Date.now())).toBe(true);
+    });
+  });
+
+  describe("dueSchedules", () => {
+    const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+    it("returns only unpaused, overdue schedules, most overdue first", () => {
+      const now = Date.UTC(2026, 5, 1);
+      // startAt is one period *before* the due date, since nextRunAt = startAt + one period.
+      const soon = createFundingSchedule("Soon", C_ADDRESS, "10", "USDC", "weekly", now - WEEK_MS - 1_000)!;
+      const veryOverdue = createFundingSchedule("Very overdue", C_ADDRESS, "10", "USDC", "weekly", now - WEEK_MS - 100_000)!;
+      const notYetDue = createFundingSchedule("Not due", C_ADDRESS, "10", "USDC", "weekly", now - WEEK_MS + 1_000_000)!;
+      pauseFundingSchedule(
+        createFundingSchedule("Paused but overdue", C_ADDRESS, "10", "USDC", "weekly", now - WEEK_MS - 5_000)!.id
+      );
+
+      const due = dueSchedules(loadFundingSchedules(), now);
+      expect(due.map((s) => s.id)).toEqual([veryOverdue.id, soon.id]);
+      expect(due.find((s) => s.id === notYetDue.id)).toBeUndefined();
+    });
+  });
+
+  describe("markScheduleCompleted", () => {
+    it("advances nextRunAt by one period from the occurrence that was due, not from now", () => {
+      const dueAt = Date.UTC(2026, 0, 1);
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", dueAt - 7 * 24 * 60 * 60 * 1000)!;
+      expect(schedule.nextRunAt).toBe(dueAt);
+
+      // Completed 3 days late — cadence should still anchor to dueAt, not "now".
+      const lateNow = dueAt + 3 * 24 * 60 * 60 * 1000;
+      const updated = markScheduleCompleted(schedule.id, lateNow);
+
+      expect(updated).not.toBeNull();
+      expect(updated!.nextRunAt).toBe(computeNextRunAt("weekly", dueAt));
+      expect(updated!.lastCompletedAt).toBe(lateNow);
+    });
+
+    it("returns null for an unknown id", () => {
+      expect(markScheduleCompleted("nope")).toBeNull();
+    });
+  });
+
+  describe("checkAndNotifyDueSchedules", () => {
+    const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+    it("records a schedule notification for each newly-due schedule", () => {
+      const now = Date.UTC(2026, 5, 1);
+      createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", now - WEEK_MS - 1_000);
+      createFundingSchedule("Not due yet", C_ADDRESS, "50", "USDC", "weekly", now - WEEK_MS + 1_000_000);
+
+      const notified = checkAndNotifyDueSchedules(now);
+      expect(notified).toHaveLength(1);
+      expect(notified[0].label).toBe("Rent");
+
+      const notifications = loadNotifications();
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0].kind).toBe("schedule");
+      expect(notifications[0].title).toContain("due");
+    });
+
+    it("does not re-notify for the same due occurrence on a second call", () => {
+      const now = Date.UTC(2026, 5, 1);
+      createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", now - WEEK_MS - 1_000);
+
+      expect(checkAndNotifyDueSchedules(now)).toHaveLength(1);
+      expect(checkAndNotifyDueSchedules(now + 60_000)).toHaveLength(0);
+      expect(loadNotifications()).toHaveLength(1);
+    });
+
+    it("notifies again once the schedule is completed and becomes due a second time", () => {
+      const firstDueAt = Date.UTC(2026, 5, 1);
+      const schedule = createFundingSchedule(
+        "Rent",
+        C_ADDRESS,
+        "100",
+        "USDC",
+        "weekly",
+        firstDueAt - 7 * 24 * 60 * 60 * 1000
+      )!;
+
+      expect(checkAndNotifyDueSchedules(firstDueAt)).toHaveLength(1);
+      markScheduleCompleted(schedule.id, firstDueAt);
+
+      const secondDueAt = computeNextRunAt("weekly", firstDueAt);
+      expect(checkAndNotifyDueSchedules(secondDueAt)).toHaveLength(1);
+      expect(loadNotifications()).toHaveLength(2);
+    });
+
+    it("does not notify for a paused schedule", () => {
+      const now = Date.UTC(2026, 5, 1);
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", now - WEEK_MS - 1_000)!;
+      pauseFundingSchedule(schedule.id);
+      expect(checkAndNotifyDueSchedules(now)).toHaveLength(0);
+      expect(loadNotifications()).toHaveLength(0);
+    });
+  });
+
+  describe("buildScheduleFundingLink", () => {
+    it("builds a funding link pre-filled with the schedule's target/amount/asset", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+      const link = buildScheduleFundingLink("https://example.com/bridge", schedule);
+      const url = new URL(link);
+      expect(url.searchParams.get("target")).toBe(C_ADDRESS);
+      expect(url.searchParams.get("amount")).toBe("100");
+      expect(url.searchParams.get("asset")).toBe("USDC");
+    });
+  });
+
+  describe("formatFrequency / isFundingFrequency", () => {
+    it("formats every supported frequency", () => {
+      expect(formatFrequency("weekly")).toBe("Weekly");
+      expect(formatFrequency("biweekly")).toBe("Every 2 weeks");
+      expect(formatFrequency("monthly")).toBe("Monthly");
+    });
+
+    it("recognises exactly the supported frequency set", () => {
+      for (const f of FUNDING_FREQUENCIES) expect(isFundingFrequency(f)).toBe(true);
+      expect(isFundingFrequency("yearly")).toBe(false);
+      expect(isFundingFrequency(42)).toBe(false);
+    });
+  });
+});

--- a/src/lib/__tests__/fundingSchedules.test.ts
+++ b/src/lib/__tests__/fundingSchedules.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Keypair, StrKey } from "@stellar/stellar-sdk";
+import { loadNotifications } from "../notifications";
+import {
+  FUNDING_FREQUENCIES,
+  MAX_FUNDING_SCHEDULES,
+  SCHEDULE_LABEL_MAX_LENGTH,
+  buildScheduleFundingLink,
+  checkAndNotifyDueSchedules,
+  computeNextRunAt,
+  createFundingSchedule,
+  deleteFundingSchedule,
+  dueSchedules,
+  formatFrequency,
+  isFundingFrequency,
+  isRenderableSchedule,
+  isScheduleDue,
+  loadFundingSchedules,
+  markScheduleCompleted,
+  pauseFundingSchedule,
+  resumeFundingSchedule,
+  updateFundingSchedule,
+  validateFundingSchedule,
+} from "../fundingSchedules";
+
+/**
+ * Unit tests for the recurring funding schedule store (#557). Structured
+ * like `addressBook.test.ts`: interesting cases are untrusted-storage shapes
+ * and the calendar/notification edge cases specific to "due on a recurring
+ * cadence". SSR behaviour is covered separately in
+ * `fundingSchedules.ssr.test.ts`.
+ */
+
+const C_ADDRESS = StrKey.encodeContract(Keypair.random().rawPublicKey());
+const C_ADDRESS_2 = StrKey.encodeContract(Keypair.random().rawPublicKey());
+const G_ADDRESS = Keypair.random().publicKey();
+
+describe("recurring funding schedules (#557)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe("validateFundingSchedule", () => {
+    it("accepts a well-formed schedule", () => {
+      const result = validateFundingSchedule(" Rent ", C_ADDRESS, "100", "USDC", "monthly");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.label).toBe("Rent"); // trimmed
+        expect(result.targetAddress).toBe(C_ADDRESS);
+      }
+    });
+
+    it("rejects an empty label", () => {
+      const result = validateFundingSchedule("   ", C_ADDRESS, "100", "USDC", "monthly");
+      expect(result).toEqual({ ok: false, error: "Label is required" });
+    });
+
+    it("rejects a label over the length budget", () => {
+      const result = validateFundingSchedule("x".repeat(SCHEDULE_LABEL_MAX_LENGTH + 1), C_ADDRESS, "100", "USDC", "monthly");
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects a G-address (must be a C-address, mirroring batch funding)", () => {
+      const result = validateFundingSchedule("Rent", G_ADDRESS, "100", "USDC", "monthly");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("G-address");
+    });
+
+    it("rejects an invalid amount", () => {
+      const result = validateFundingSchedule("Rent", C_ADDRESS, "-5", "USDC", "monthly");
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects an unsupported asset", () => {
+      const result = validateFundingSchedule("Rent", C_ADDRESS, "100", "BTC", "monthly");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("Unsupported asset");
+    });
+
+    it("rejects an unsupported frequency", () => {
+      const result = validateFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "daily");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("Unsupported frequency");
+    });
+  });
+
+  describe("computeNextRunAt", () => {
+    it("advances weekly by exactly 7 days", () => {
+      const from = Date.UTC(2026, 0, 1); // Jan 1, 2026
+      expect(computeNextRunAt("weekly", from)).toBe(from + 7 * 24 * 60 * 60 * 1000);
+    });
+
+    it("advances biweekly by exactly 14 days", () => {
+      const from = Date.UTC(2026, 0, 1);
+      expect(computeNextRunAt("biweekly", from)).toBe(from + 14 * 24 * 60 * 60 * 1000);
+    });
+
+    it("advances monthly to the same day next month in the common case", () => {
+      const from = Date.UTC(2026, 0, 15); // Jan 15, 2026
+      const next = new Date(computeNextRunAt("monthly", from));
+      expect(next.getUTCFullYear()).toBe(2026);
+      expect(next.getUTCMonth()).toBe(1); // February
+      expect(next.getUTCDate()).toBe(15);
+    });
+
+    it("clamps a month-end date instead of overflowing into the following month", () => {
+      const from = Date.UTC(2026, 0, 31); // Jan 31, 2026
+      const next = new Date(computeNextRunAt("monthly", from));
+      // Feb 2026 has 28 days — must clamp to Feb 28, not spill into March.
+      expect(next.getUTCMonth()).toBe(1);
+      expect(next.getUTCDate()).toBe(28);
+    });
+
+    it("handles a December -> January year rollover", () => {
+      const from = Date.UTC(2026, 11, 15); // Dec 15, 2026
+      const next = new Date(computeNextRunAt("monthly", from));
+      expect(next.getUTCFullYear()).toBe(2027);
+      expect(next.getUTCMonth()).toBe(0);
+      expect(next.getUTCDate()).toBe(15);
+    });
+  });
+
+  describe("createFundingSchedule / loadFundingSchedules", () => {
+    it("creates a schedule with nextRunAt one period ahead of startAt", () => {
+      const startAt = Date.UTC(2026, 0, 1);
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", startAt);
+      expect(schedule).not.toBeNull();
+      expect(schedule!.nextRunAt).toBe(computeNextRunAt("weekly", startAt));
+      expect(schedule!.paused).toBe(false);
+      expect(loadFundingSchedules()).toHaveLength(1);
+    });
+
+    it("returns null and saves nothing for invalid input", () => {
+      expect(createFundingSchedule("", C_ADDRESS, "100", "USDC", "weekly")).toBeNull();
+      expect(loadFundingSchedules()).toHaveLength(0);
+    });
+
+    it("enforces the MAX_FUNDING_SCHEDULES cap", () => {
+      for (let i = 0; i < MAX_FUNDING_SCHEDULES; i++) {
+        expect(createFundingSchedule(`Sched ${i}`, C_ADDRESS, "10", "USDC", "weekly")).not.toBeNull();
+      }
+      expect(loadFundingSchedules()).toHaveLength(MAX_FUNDING_SCHEDULES);
+      expect(createFundingSchedule("One too many", C_ADDRESS, "10", "USDC", "weekly")).toBeNull();
+      expect(loadFundingSchedules()).toHaveLength(MAX_FUNDING_SCHEDULES);
+    });
+  });
+
+  describe("isRenderableSchedule", () => {
+    it("drops entries with an invalid target address (e.g. hand-edited storage)", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly");
+      window.localStorage.setItem(
+        "fundingSchedules:v1",
+        JSON.stringify([{ ...schedule, targetAddress: "not-an-address" }])
+      );
+      expect(loadFundingSchedules()).toHaveLength(0);
+    });
+
+    it("drops entries with an unknown frequency", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly");
+      window.localStorage.setItem(
+        "fundingSchedules:v1",
+        JSON.stringify([{ ...schedule, frequency: "yearly" }])
+      );
+      expect(loadFundingSchedules()).toHaveLength(0);
+    });
+
+    it("is fine with a non-object entry rejected outright", () => {
+      expect(isRenderableSchedule("nope")).toBe(false);
+      expect(isRenderableSchedule(null)).toBe(false);
+    });
+  });
+
+  describe("updateFundingSchedule", () => {
+    it("updates fields and recomputes nextRunAt when frequency changes", () => {
+      const startAt = Date.UTC(2026, 0, 1);
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", startAt)!;
+      const originalNextRunAt = schedule.nextRunAt;
+
+      const ok = updateFundingSchedule(schedule.id, "Rent (updated)", C_ADDRESS_2, "150", "XLM", "monthly");
+      expect(ok).toBe(true);
+
+      const [updated] = loadFundingSchedules();
+      expect(updated.label).toBe("Rent (updated)");
+      expect(updated.targetAddress).toBe(C_ADDRESS_2);
+      expect(updated.amount).toBe("150");
+      expect(updated.asset).toBe("XLM");
+      expect(updated.frequency).toBe("monthly");
+      expect(updated.nextRunAt).not.toBe(originalNextRunAt);
+    });
+
+    it("leaves nextRunAt untouched when frequency doesn't change", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+      updateFundingSchedule(schedule.id, "Rent v2", C_ADDRESS, "200", "USDC", "weekly");
+      const [updated] = loadFundingSchedules();
+      expect(updated.nextRunAt).toBe(schedule.nextRunAt);
+    });
+
+    it("returns false for an unknown id", () => {
+      expect(updateFundingSchedule("nope", "Rent", C_ADDRESS, "100", "USDC", "weekly")).toBe(false);
+    });
+
+    it("returns false and leaves storage untouched for invalid input", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+      expect(updateFundingSchedule(schedule.id, "", C_ADDRESS, "100", "USDC", "weekly")).toBe(false);
+      expect(loadFundingSchedules()[0].label).toBe("Rent");
+    });
+  });
+
+  describe("deleteFundingSchedule", () => {
+    it("removes the schedule and returns true", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+      expect(deleteFundingSchedule(schedule.id)).toBe(true);
+      expect(loadFundingSchedules()).toHaveLength(0);
+    });
+
+    it("returns false for an id that doesn't exist", () => {
+      expect(deleteFundingSchedule("nope")).toBe(false);
+    });
+  });
+
+  describe("pauseFundingSchedule / resumeFundingSchedule", () => {
+    it("pausing excludes a due schedule from isScheduleDue", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", 0)!;
+      expect(isScheduleDue(schedule, Date.now())).toBe(true);
+
+      pauseFundingSchedule(schedule.id);
+      const [paused] = loadFundingSchedules();
+      expect(isScheduleDue(paused, Date.now())).toBe(false);
+
+      resumeFundingSchedule(schedule.id);
+      const [resumed] = loadFundingSchedules();
+      expect(isScheduleDue(resumed, Date.now())).toBe(true);
+    });
+  });
+
+  describe("dueSchedules", () => {
+    const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+    it("returns only unpaused, overdue schedules, most overdue first", () => {
+      const now = Date.UTC(2026, 5, 1);
+      // startAt is one period *before* the due date, since nextRunAt = startAt + one period.
+      const soon = createFundingSchedule("Soon", C_ADDRESS, "10", "USDC", "weekly", now - WEEK_MS - 1_000)!;
+      const veryOverdue = createFundingSchedule("Very overdue", C_ADDRESS, "10", "USDC", "weekly", now - WEEK_MS - 100_000)!;
+      const notYetDue = createFundingSchedule("Not due", C_ADDRESS, "10", "USDC", "weekly", now - WEEK_MS + 1_000_000)!;
+      pauseFundingSchedule(
+        createFundingSchedule("Paused but overdue", C_ADDRESS, "10", "USDC", "weekly", now - WEEK_MS - 5_000)!.id
+      );
+
+      const due = dueSchedules(loadFundingSchedules(), now);
+      expect(due.map((s) => s.id)).toEqual([veryOverdue.id, soon.id]);
+      expect(due.find((s) => s.id === notYetDue.id)).toBeUndefined();
+    });
+  });
+
+  describe("markScheduleCompleted", () => {
+    it("advances nextRunAt by one period from the occurrence that was due, not from now", () => {
+      const dueAt = Date.UTC(2026, 0, 1);
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", dueAt - 7 * 24 * 60 * 60 * 1000)!;
+      expect(schedule.nextRunAt).toBe(dueAt);
+
+      // Completed 3 days late — cadence should still anchor to dueAt, not "now".
+      const lateNow = dueAt + 3 * 24 * 60 * 60 * 1000;
+      const updated = markScheduleCompleted(schedule.id, lateNow);
+
+      expect(updated).not.toBeNull();
+      expect(updated!.nextRunAt).toBe(computeNextRunAt("weekly", dueAt));
+      expect(updated!.lastCompletedAt).toBe(lateNow);
+    });
+
+    it("returns null for an unknown id", () => {
+      expect(markScheduleCompleted("nope")).toBeNull();
+    });
+  });
+
+  describe("checkAndNotifyDueSchedules", () => {
+    const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+    it("records a schedule notification for each newly-due schedule", () => {
+      const now = Date.UTC(2026, 5, 1);
+      createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", now - WEEK_MS - 1_000);
+      createFundingSchedule("Not due yet", C_ADDRESS, "50", "USDC", "weekly", now - WEEK_MS + 1_000_000);
+
+      const notified = checkAndNotifyDueSchedules(now);
+      expect(notified).toHaveLength(1);
+      expect(notified[0].label).toBe("Rent");
+
+      const notifications = loadNotifications();
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0].kind).toBe("schedule");
+      expect(notifications[0].title).toContain("due");
+    });
+
+    it("does not re-notify for the same due occurrence on a second call", () => {
+      const now = Date.UTC(2026, 5, 1);
+      createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", now - WEEK_MS - 1_000);
+
+      expect(checkAndNotifyDueSchedules(now)).toHaveLength(1);
+      expect(checkAndNotifyDueSchedules(now + 60_000)).toHaveLength(0);
+      expect(loadNotifications()).toHaveLength(1);
+    });
+
+    it("notifies again once the schedule is completed and becomes due a second time", () => {
+      const firstDueAt = Date.UTC(2026, 5, 1);
+      const schedule = createFundingSchedule(
+        "Rent",
+        C_ADDRESS,
+        "100",
+        "USDC",
+        "weekly",
+        firstDueAt - 7 * 24 * 60 * 60 * 1000
+      )!;
+
+      expect(checkAndNotifyDueSchedules(firstDueAt)).toHaveLength(1);
+      markScheduleCompleted(schedule.id, firstDueAt);
+
+      const secondDueAt = computeNextRunAt("weekly", firstDueAt);
+      expect(checkAndNotifyDueSchedules(secondDueAt)).toHaveLength(1);
+      expect(loadNotifications()).toHaveLength(2);
+    });
+
+    it("does not notify for a paused schedule", () => {
+      const now = Date.UTC(2026, 5, 1);
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly", now - WEEK_MS - 1_000)!;
+      pauseFundingSchedule(schedule.id);
+      expect(checkAndNotifyDueSchedules(now)).toHaveLength(0);
+      expect(loadNotifications()).toHaveLength(0);
+    });
+  });
+
+  describe("buildScheduleFundingLink", () => {
+    it("builds a funding link pre-filled with the schedule's target/amount/asset", () => {
+      const schedule = createFundingSchedule("Rent", C_ADDRESS, "100", "USDC", "weekly")!;
+      const link = buildScheduleFundingLink("https://example.com/bridge", schedule);
+      const url = new URL(link);
+      expect(url.searchParams.get("target")).toBe(C_ADDRESS);
+      expect(url.searchParams.get("amount")).toBe("100");
+      expect(url.searchParams.get("asset")).toBe("USDC");
+    });
+  });
+
+  describe("formatFrequency / isFundingFrequency", () => {
+    it("formats every supported frequency", () => {
+      expect(formatFrequency("weekly")).toBe("Weekly");
+      expect(formatFrequency("biweekly")).toBe("Every 2 weeks");
+      expect(formatFrequency("monthly")).toBe("Monthly");
+    });
+
+    it("recognises exactly the supported frequency set", () => {
+      for (const f of FUNDING_FREQUENCIES) expect(isFundingFrequency(f)).toBe(true);
+      expect(isFundingFrequency("yearly")).toBe(false);
+      expect(isFundingFrequency(42)).toBe(false);
+    });
+  });
+});

--- a/src/lib/__tests__/onrampQuotes.test.ts
+++ b/src/lib/__tests__/onrampQuotes.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import {
+  bestQuote,
+  buildEstimatedQuote,
+  compareOnrampQuotes,
+  formatQuoteFeeRate,
+  isWithinLimits,
+  parseProviderLimits,
+  quoteSpread,
+  rankQuotes,
+  type OnrampQuoteComparison,
+} from "../onrampQuotes";
+
+describe("parseProviderLimits", () => {
+  it("parses the standard '$min - $max' shape", () => {
+    expect(parseProviderLimits("$20 - $10,000")).toEqual({ min: 20, max: 10000 });
+    expect(parseProviderLimits("$15 - $25,000")).toEqual({ min: 15, max: 25000 });
+  });
+
+  it("returns null for an unparseable string", () => {
+    expect(parseProviderLimits("no limits")).toBeNull();
+    expect(parseProviderLimits("")).toBeNull();
+  });
+});
+
+describe("isWithinLimits", () => {
+  const limits = { min: 20, max: 10000 };
+
+  it("is true at and between the bounds, inclusive", () => {
+    expect(isWithinLimits(20, limits)).toBe(true);
+    expect(isWithinLimits(10000, limits)).toBe(true);
+    expect(isWithinLimits(500, limits)).toBe(true);
+  });
+
+  it("is false outside the bounds", () => {
+    expect(isWithinLimits(19.99, limits)).toBe(false);
+    expect(isWithinLimits(10000.01, limits)).toBe(false);
+  });
+
+  it("is null (unknown, not unlimited) when limits are null", () => {
+    expect(isWithinLimits(500, null)).toBeNull();
+  });
+});
+
+describe("buildEstimatedQuote", () => {
+  it("computes moonpay's 4.5% fee against the requested amount", () => {
+    const q = buildEstimatedQuote("moonpay", 100, "USD", 1_000_000);
+    expect(q.provider).toBe("moonpay");
+    expect(q.source).toBe("estimated");
+    expect(q.quotedAt).toBe(1_000_000);
+    expect(q.fee).toBe("4.50");
+    expect(q.destinationAmount).toBe("95.50");
+    expect(q.cryptoCurrency).toBe("USDC");
+    expect(q.withinLimits).toBe(true);
+  });
+
+  it("computes transak's 5% fee against the requested amount", () => {
+    const q = buildEstimatedQuote("transak", 100, "USD");
+    expect(q.fee).toBe("5.00");
+    expect(q.destinationAmount).toBe("95.00");
+  });
+
+  it("flags an amount below a provider's minimum as not within limits", () => {
+    const q = buildEstimatedQuote("moonpay", 5, "USD");
+    expect(q.withinLimits).toBe(false);
+  });
+});
+
+describe("rankQuotes", () => {
+  function quote(destinationAmount: string): OnrampQuoteComparison {
+    return {
+      provider: "moonpay",
+      providerName: "Moonpay",
+      sourceAmount: "100",
+      destinationAmount,
+      fee: "0",
+      fiatCurrency: "USD",
+      cryptoCurrency: "USDC",
+      source: "estimated",
+      quotedAt: 0,
+      rank: 0,
+      isBest: false,
+      limits: null,
+      withinLimits: null,
+    };
+  }
+
+  it("ranks strictly descending quotes 1, 2, 3", () => {
+    const [a, b, c] = rankQuotes([quote("90"), quote("95"), quote("100")]);
+    // input order preserved by value, but ranks/isBest reflect sorted position
+    expect(rankQuotes([quote("90"), quote("95"), quote("100")]).map((q) => q.destinationAmount)).toEqual([
+      "100",
+      "95",
+      "90",
+    ]);
+    const sorted = rankQuotes([quote("90"), quote("95"), quote("100")]);
+    expect(sorted.map((q) => q.rank)).toEqual([1, 2, 3]);
+    expect(sorted.map((q) => q.isBest)).toEqual([true, false, false]);
+    void a;
+    void b;
+    void c;
+  });
+
+  it("uses dense ranking so tied quotes share a rank and the next rank doesn't skip", () => {
+    const sorted = rankQuotes([quote("95"), quote("95"), quote("90")]);
+    expect(sorted.map((q) => q.rank)).toEqual([1, 1, 2]);
+    expect(sorted.map((q) => q.isBest)).toEqual([true, true, false]);
+  });
+
+  it("marks every provider best in an all-tied comparison", () => {
+    const sorted = rankQuotes([quote("50"), quote("50")]);
+    expect(sorted.every((q) => q.isBest)).toBe(true);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [quote("90"), quote("100")];
+    const before = input.map((q) => ({ ...q }));
+    rankQuotes(input);
+    expect(input).toEqual(before);
+  });
+});
+
+describe("compareOnrampQuotes", () => {
+  it("ranks moonpay above transak for a plain USD amount (lower fee rate wins)", () => {
+    const comparisons = compareOnrampQuotes(100, "USD");
+    expect(comparisons).toHaveLength(2);
+    expect(comparisons[0].provider).toBe("moonpay");
+    expect(comparisons[0].isBest).toBe(true);
+    expect(comparisons[1].provider).toBe("transak");
+    expect(comparisons[1].isBest).toBe(false);
+  });
+
+  it("excludes providers that don't support the requested currency", () => {
+    // Only Transak supports INR.
+    const comparisons = compareOnrampQuotes(100, "INR");
+    expect(comparisons).toHaveLength(1);
+    expect(comparisons[0].provider).toBe("transak");
+  });
+
+  it("returns an empty comparison for a non-positive or non-finite amount", () => {
+    expect(compareOnrampQuotes(0, "USD")).toEqual([]);
+    expect(compareOnrampQuotes(-5, "USD")).toEqual([]);
+    expect(compareOnrampQuotes(NaN, "USD")).toEqual([]);
+  });
+
+  it("uses a supplied live quote instead of the estimate, tagged source: live", () => {
+    const comparisons = compareOnrampQuotes(100, "USD", {
+      liveQuotes: {
+        transak: { sourceAmount: "100", destinationAmount: "99.00", fee: "1.00" },
+      },
+    });
+    const transak = comparisons.find((q) => q.provider === "transak");
+    const moonpay = comparisons.find((q) => q.provider === "moonpay");
+    expect(transak?.source).toBe("live");
+    expect(transak?.destinationAmount).toBe("99.00");
+    // A live quote for one provider doesn't disturb the other's estimate.
+    expect(moonpay?.source).toBe("estimated");
+    // With the live figure, transak now out-ranks moonpay's 95.50 estimate.
+    expect(transak?.isBest).toBe(true);
+  });
+
+  it("falls back to the estimate when a provider has no live quote (failure isolation)", () => {
+    // Simulates /api/onramp/quotes returning a live quote for only one
+    // provider because the other's fetch failed or timed out upstream.
+    const comparisons = compareOnrampQuotes(100, "USD", {
+      liveQuotes: { moonpay: { sourceAmount: "100", destinationAmount: "96.00", fee: "4.00" } },
+    });
+    const transak = comparisons.find((q) => q.provider === "transak");
+    expect(transak?.source).toBe("estimated");
+    expect(transak?.destinationAmount).toBe("95.00");
+  });
+
+  it("ties both providers when their receive amounts are equal", () => {
+    const comparisons = compareOnrampQuotes(100, "USD", {
+      liveQuotes: {
+        transak: { sourceAmount: "100", destinationAmount: "95.50", fee: "4.50" },
+      },
+    });
+    expect(comparisons.every((q) => q.rank === 1 && q.isBest)).toBe(true);
+  });
+});
+
+describe("bestQuote", () => {
+  it("returns the top-ranked entry", () => {
+    const comparisons = compareOnrampQuotes(100, "USD");
+    expect(bestQuote(comparisons)?.provider).toBe("moonpay");
+  });
+
+  it("returns null for an empty comparison", () => {
+    expect(bestQuote([])).toBeNull();
+  });
+});
+
+describe("quoteSpread", () => {
+  it("is null with fewer than two quotes", () => {
+    expect(quoteSpread([])).toBeNull();
+    expect(quoteSpread(compareOnrampQuotes(100, "INR"))).toBeNull(); // only transak supports INR
+  });
+
+  it("computes the absolute and percentage gap between best and worst", () => {
+    const spread = quoteSpread(compareOnrampQuotes(100, "USD"));
+    expect(spread).not.toBeNull();
+    expect(spread!.absolute).toBeCloseTo(0.5, 5); // 95.50 - 95.00
+    expect(spread!.percent).toBeCloseTo((0.5 / 95.5) * 100, 5);
+  });
+});
+
+describe("formatQuoteFeeRate", () => {
+  it("formats each provider's fee rate as a percentage", () => {
+    expect(formatQuoteFeeRate("moonpay")).toBe("4.50%");
+    expect(formatQuoteFeeRate("transak")).toBe("5.00%");
+  });
+});

--- a/src/lib/fundingSchedules.ts
+++ b/src/lib/fundingSchedules.ts
@@ -1,0 +1,436 @@
+/**
+ * Recurring funding schedule management (#557).
+ *
+ * There is no backend, and no way for a browser tab to execute a signed
+ * transaction on a schedule while closed — the same "no backend" constraint
+ * that shapes `addressBook.ts` and `fundingLink.ts`. A "schedule" here is
+ * therefore a local reminder, not an automation: this module tracks when a
+ * recurring funding is next due, and `checkAndNotifyDueSchedules` surfaces
+ * that through the notification centre using its existing `"schedule"` kind
+ * (see `notifications.ts`'s module docs — that kind was added in #477
+ * specifically so a flow like this one could use it once it shipped).
+ * Completing a due schedule is one click away via `buildScheduleFundingLink`,
+ * which reuses `fundingLink.ts`'s pre-fill mechanism (`buildFundingLink`) so
+ * the bridge/onramp form opens with the target address, amount and asset
+ * already filled in — the user still sends it themselves.
+ *
+ * Storage/validation conventions mirror `addressBook.ts`: one JSON array in
+ * `localStorage`, SSR-safe accessors, and every stored entry re-validated on
+ * read so a corrupted or hand-edited record is dropped rather than breaking
+ * the whole list.
+ */
+import { validateBatchAddress, validateBatchAmount } from "./batchFunding";
+import { isCAddress, isValidStellarAmount } from "./stellar";
+import { hasControlChars } from "./profile";
+import { addNotification } from "./notifications";
+import { FUNDING_LINK_ASSETS, buildFundingLink, type FundingLinkAsset } from "./fundingLink";
+import { ROUTES } from "./routes";
+
+/** Same budget as a recipient label (`RECIPIENT_LABEL_MAX_LENGTH` in addressBook.ts). */
+export const SCHEDULE_LABEL_MAX_LENGTH = 32;
+
+/** Cap on saved schedules, same reasoning/order of magnitude as MAX_BATCH_RECIPIENTS (types.ts). */
+export const MAX_FUNDING_SCHEDULES = 20;
+
+const STORAGE_KEY = "fundingSchedules:v1";
+
+export const FUNDING_FREQUENCIES = ["weekly", "biweekly", "monthly"] as const;
+export type FundingFrequency = (typeof FUNDING_FREQUENCIES)[number];
+
+export function isFundingFrequency(value: unknown): value is FundingFrequency {
+  return typeof value === "string" && (FUNDING_FREQUENCIES as readonly string[]).includes(value);
+}
+
+function isFundingLinkAsset(value: unknown): value is FundingLinkAsset {
+  return typeof value === "string" && (FUNDING_LINK_ASSETS as readonly string[]).includes(value);
+}
+
+export interface FundingSchedule {
+  id: string;
+  label: string;
+  /** A Soroban C-address — recurring funding lands in a smart account, same restriction batchFunding.ts documents. */
+  targetAddress: string;
+  amount: string;
+  asset: FundingLinkAsset;
+  frequency: FundingFrequency;
+  /** Epoch ms the next funding is due. */
+  nextRunAt: number;
+  createdAt: number;
+  updatedAt: number;
+  paused: boolean;
+  /** Epoch ms the schedule was last marked completed, if ever. */
+  lastCompletedAt?: number;
+  /**
+   * The `nextRunAt` value a "this is due" notification has already been sent
+   * for. Lets `checkAndNotifyDueSchedules` run on every page load without
+   * re-notifying for the same due occurrence.
+   */
+  lastNotifiedRunAt?: number;
+}
+
+export type ScheduleValidation =
+  | {
+      ok: true;
+      label: string;
+      targetAddress: string;
+      amount: string;
+      asset: FundingLinkAsset;
+      frequency: FundingFrequency;
+    }
+  | { ok: false; error: string };
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    // Access itself throws in some privacy modes.
+    return null;
+  }
+}
+
+/**
+ * Validates and normalises the fields of a new or edited schedule. Address
+ * and amount validation are delegated to `batchFunding.ts`'s
+ * `validateBatchAddress`/`validateBatchAmount` rather than re-implemented
+ * here, so a recurring schedule and a one-off batch row always agree on what
+ * counts as a valid C-address/amount for funding.
+ */
+export function validateFundingSchedule(
+  rawLabel: string,
+  rawTargetAddress: string,
+  rawAmount: string,
+  asset: string,
+  frequency: string
+): ScheduleValidation {
+  const label = rawLabel.trim();
+  if (!label) {
+    return { ok: false, error: "Label is required" };
+  }
+  if (label.length > SCHEDULE_LABEL_MAX_LENGTH) {
+    return { ok: false, error: `Label must be ${SCHEDULE_LABEL_MAX_LENGTH} characters or fewer` };
+  }
+  if (hasControlChars(label)) {
+    return { ok: false, error: "Label cannot contain line breaks or control characters" };
+  }
+
+  const addressError = validateBatchAddress(rawTargetAddress);
+  if (addressError) {
+    return { ok: false, error: addressError };
+  }
+
+  const amountError = validateBatchAmount(rawAmount);
+  if (amountError) {
+    return { ok: false, error: amountError };
+  }
+
+  if (!isFundingLinkAsset(asset)) {
+    return {
+      ok: false,
+      error: `Unsupported asset "${asset}". Supported assets: ${FUNDING_LINK_ASSETS.join(", ")}.`,
+    };
+  }
+
+  if (!isFundingFrequency(frequency)) {
+    return {
+      ok: false,
+      error: `Unsupported frequency "${frequency}". Supported: ${FUNDING_FREQUENCIES.join(", ")}.`,
+    };
+  }
+
+  return {
+    ok: true,
+    label,
+    targetAddress: rawTargetAddress.trim(),
+    amount: rawAmount.trim(),
+    asset,
+    frequency,
+  };
+}
+
+/** True when `value` is a stored schedule in the exact shape this module writes. */
+export function isRenderableSchedule(value: unknown): value is FundingSchedule {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+
+  if (typeof v.id !== "string" || !v.id) return false;
+  if (typeof v.label !== "string" || !v.label || v.label.length > SCHEDULE_LABEL_MAX_LENGTH) return false;
+  if (hasControlChars(v.label)) return false;
+  if (typeof v.targetAddress !== "string" || !isCAddress(v.targetAddress)) return false;
+  if (typeof v.amount !== "string" || !isValidStellarAmount(v.amount)) return false;
+  if (!isFundingLinkAsset(v.asset)) return false;
+  if (!isFundingFrequency(v.frequency)) return false;
+  if (typeof v.nextRunAt !== "number" || !Number.isFinite(v.nextRunAt)) return false;
+  if (typeof v.createdAt !== "number" || !Number.isFinite(v.createdAt)) return false;
+  if (typeof v.updatedAt !== "number" || !Number.isFinite(v.updatedAt)) return false;
+  if (typeof v.paused !== "boolean") return false;
+  if (v.lastCompletedAt !== undefined && (typeof v.lastCompletedAt !== "number" || !Number.isFinite(v.lastCompletedAt))) {
+    return false;
+  }
+  if (v.lastNotifiedRunAt !== undefined && (typeof v.lastNotifiedRunAt !== "number" || !Number.isFinite(v.lastNotifiedRunAt))) {
+    return false;
+  }
+
+  return true;
+}
+
+function readRaw(): unknown[] {
+  const store = storage();
+  if (!store) return [];
+
+  let raw: string | null;
+  try {
+    raw = store.getItem(STORAGE_KEY);
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function persist(schedules: FundingSchedule[]): boolean {
+  const store = storage();
+  if (!store) return false;
+  try {
+    store.setItem(STORAGE_KEY, JSON.stringify(schedules));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function createScheduleId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `sched-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Advances `from` by one period of `frequency`. Monthly clamps to the last
+ * day of the target month instead of overflowing into the month after (e.g.
+ * Jan 31 + 1 month -> Feb 28/29, not Mar 3) — the same kind of calendar edge
+ * case `computeNextRunAt`'s callers rely on being handled once, correctly,
+ * rather than re-solved ad hoc.
+ */
+export function computeNextRunAt(frequency: FundingFrequency, from: number): number {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  if (frequency === "weekly") return from + 7 * DAY_MS;
+  if (frequency === "biweekly") return from + 14 * DAY_MS;
+
+  const d = new Date(from);
+  const next = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1));
+  const daysInNextMonth = new Date(Date.UTC(next.getUTCFullYear(), next.getUTCMonth() + 1, 0)).getUTCDate();
+  next.setUTCDate(Math.min(d.getUTCDate(), daysInNextMonth));
+  next.setUTCHours(d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds(), d.getUTCMilliseconds());
+  return next.getTime();
+}
+
+/** Human-readable frequency label, e.g. for the schedule list. */
+export function formatFrequency(frequency: FundingFrequency): string {
+  switch (frequency) {
+    case "weekly":
+      return "Weekly";
+    case "biweekly":
+      return "Every 2 weeks";
+    case "monthly":
+      return "Monthly";
+  }
+}
+
+/** Reads the saved schedules, dropping any entry that fails re-validation. */
+export function loadFundingSchedules(): FundingSchedule[] {
+  return readRaw().filter(isRenderableSchedule);
+}
+
+/**
+ * Creates a new schedule. `startAt` (default: now) is the point the first
+ * `nextRunAt` is computed one period forward from — exposed mainly for
+ * deterministic tests; callers scheduling "starting today" can omit it.
+ * Returns null when validation fails, the schedule cap
+ * (`MAX_FUNDING_SCHEDULES`) is already reached, or the write failed.
+ */
+export function createFundingSchedule(
+  rawLabel: string,
+  rawTargetAddress: string,
+  rawAmount: string,
+  asset: string,
+  frequency: string,
+  startAt: number = Date.now()
+): FundingSchedule | null {
+  const result = validateFundingSchedule(rawLabel, rawTargetAddress, rawAmount, asset, frequency);
+  if (!result.ok) return null;
+
+  const existing = loadFundingSchedules();
+  if (existing.length >= MAX_FUNDING_SCHEDULES) return null;
+
+  const now = Date.now();
+  const schedule: FundingSchedule = {
+    id: createScheduleId(),
+    label: result.label,
+    targetAddress: result.targetAddress,
+    amount: result.amount,
+    asset: result.asset,
+    frequency: result.frequency,
+    nextRunAt: computeNextRunAt(result.frequency, startAt),
+    createdAt: now,
+    updatedAt: now,
+    paused: false,
+  };
+
+  if (!persist([...existing, schedule])) return null;
+  return schedule;
+}
+
+/**
+ * Updates an existing schedule's editable fields by id. Changing the
+ * frequency recomputes `nextRunAt` from now (rather than leaving a stale
+ * cadence in place); everything else about `nextRunAt`/`paused` is left
+ * untouched. Returns false when validation fails, the id doesn't exist, or
+ * the write failed.
+ */
+export function updateFundingSchedule(
+  id: string,
+  rawLabel: string,
+  rawTargetAddress: string,
+  rawAmount: string,
+  asset: string,
+  frequency: string
+): boolean {
+  const result = validateFundingSchedule(rawLabel, rawTargetAddress, rawAmount, asset, frequency);
+  if (!result.ok) return false;
+
+  const existing = loadFundingSchedules();
+  const index = existing.findIndex((s) => s.id === id);
+  if (index === -1) return false;
+
+  const current = existing[index];
+  const frequencyChanged = current.frequency !== result.frequency;
+  const updated: FundingSchedule = {
+    ...current,
+    label: result.label,
+    targetAddress: result.targetAddress,
+    amount: result.amount,
+    asset: result.asset,
+    frequency: result.frequency,
+    nextRunAt: frequencyChanged ? computeNextRunAt(result.frequency, Date.now()) : current.nextRunAt,
+    updatedAt: Date.now(),
+  };
+
+  const next = [...existing];
+  next[index] = updated;
+  return persist(next);
+}
+
+/** Removes a schedule by id. Returns false if the id wasn't found or the write failed. */
+export function deleteFundingSchedule(id: string): boolean {
+  const existing = loadFundingSchedules();
+  const next = existing.filter((s) => s.id !== id);
+  if (next.length === existing.length) return false;
+  return persist(next);
+}
+
+/** Pauses a schedule (it is excluded from `dueSchedules`/notifications until resumed). */
+export function pauseFundingSchedule(id: string): boolean {
+  return setPaused(id, true);
+}
+
+/** Resumes a paused schedule. Does not change `nextRunAt` — a schedule paused while overdue is immediately due again. */
+export function resumeFundingSchedule(id: string): boolean {
+  return setPaused(id, false);
+}
+
+function setPaused(id: string, paused: boolean): boolean {
+  const existing = loadFundingSchedules();
+  const index = existing.findIndex((s) => s.id === id);
+  if (index === -1) return false;
+  const next = [...existing];
+  next[index] = { ...existing[index], paused, updatedAt: Date.now() };
+  return persist(next);
+}
+
+/** True when an unpaused schedule's `nextRunAt` has passed. */
+export function isScheduleDue(schedule: Pick<FundingSchedule, "paused" | "nextRunAt">, now: number = Date.now()): boolean {
+  return !schedule.paused && schedule.nextRunAt <= now;
+}
+
+/** Due schedules, most overdue first. */
+export function dueSchedules(schedules: FundingSchedule[], now: number = Date.now()): FundingSchedule[] {
+  return schedules.filter((s) => isScheduleDue(s, now)).sort((a, b) => a.nextRunAt - b.nextRunAt);
+}
+
+/**
+ * Marks a schedule as completed for its current due occurrence: advances
+ * `nextRunAt` by one period *from the occurrence that was due* (not from
+ * `now`), so a schedule completed a few days late stays on its original
+ * cadence instead of drifting later with every late completion. Records
+ * `lastCompletedAt`. Returns null if the id doesn't exist or the write
+ * failed.
+ */
+export function markScheduleCompleted(id: string, now: number = Date.now()): FundingSchedule | null {
+  const existing = loadFundingSchedules();
+  const index = existing.findIndex((s) => s.id === id);
+  if (index === -1) return null;
+
+  const current = existing[index];
+  const updated: FundingSchedule = {
+    ...current,
+    nextRunAt: computeNextRunAt(current.frequency, current.nextRunAt),
+    lastCompletedAt: now,
+    updatedAt: now,
+  };
+
+  const next = [...existing];
+  next[index] = updated;
+  if (!persist(next)) return null;
+  return updated;
+}
+
+/**
+ * Builds a pre-filled funding link for a schedule via `fundingLink.ts`'s
+ * `buildFundingLink`, so acting on a due schedule never means re-typing the
+ * address/amount by hand.
+ */
+export function buildScheduleFundingLink(baseUrl: string, schedule: Pick<FundingSchedule, "targetAddress" | "amount" | "asset">): string {
+  return buildFundingLink(baseUrl, {
+    target: schedule.targetAddress,
+    amount: schedule.amount,
+    asset: schedule.asset,
+  });
+}
+
+/**
+ * Checks for schedules that are due and haven't been notified for their
+ * current `nextRunAt` yet, records one "schedule"-kind notification each via
+ * `notifications.ts`'s `addNotification`, and stamps `lastNotifiedRunAt` so
+ * re-running this on every page load doesn't re-notify for the same due
+ * occurrence. Returns the schedules that were (newly) notified.
+ */
+export function checkAndNotifyDueSchedules(now: number = Date.now()): FundingSchedule[] {
+  const schedules = loadFundingSchedules();
+  const due = schedules.filter(
+    (s) => isScheduleDue(s, now) && s.lastNotifiedRunAt !== s.nextRunAt
+  );
+  if (due.length === 0) return [];
+
+  const dueIds = new Set(due.map((s) => s.id));
+  const next = schedules.map((s) => (dueIds.has(s.id) ? { ...s, lastNotifiedRunAt: s.nextRunAt } : s));
+  persist(next);
+
+  for (const s of due) {
+    addNotification({
+      kind: "schedule",
+      title: "Recurring funding due",
+      message: `"${s.label}" — ${s.amount} ${s.asset} to ${s.targetAddress.slice(0, 8)}… is due.`,
+      href: ROUTES.SCHEDULES,
+    });
+  }
+
+  return due;
+}

--- a/src/lib/onrampQuotes.ts
+++ b/src/lib/onrampQuotes.ts
@@ -1,0 +1,214 @@
+/**
+ * On-ramp provider quote comparison (#556).
+ *
+ * The onramp page already computes a correct fee/net-receive estimate per
+ * provider (`getProviderFeeRate`/`calculateOnrampFeeAndReceive` in
+ * `onramp-page.tsx`) — and because the only crypto asset this app on-ramps
+ * into is USDC, a dollar-pegged stablecoin, that estimate does not depend on
+ * a live crypto price feed the way a BTC/ETH quote would. This module turns
+ * that per-provider estimate into a ranked, side-by-side comparison, and
+ * defines the shape a live quote (fetched by `/api/onramp/quotes`, or any
+ * future provider integration) must have to slot into the same ranking:
+ * `source: "live"` quotes and `source: "estimated"` ones are ranked
+ * identically, so a provider whose live quote fails or isn't configured
+ * degrades to its estimate rather than dropping out of the comparison.
+ */
+import { providers, getProviderFeeRate, calculateOnrampFeeAndReceive } from "@/components/routes/onramp-page";
+import type { OnrampProvider, OnrampQuote } from "./types";
+import { isOnrampProvider } from "./types";
+
+export { formatNotificationAge as formatQuoteAge } from "./notifications";
+
+/** Where a quote's numbers came from. */
+export type QuoteSource = "live" | "estimated";
+
+/** Parsed `$min - $max` bounds from a provider's advertised limits string. */
+export interface QuoteLimits {
+  min: number;
+  max: number;
+}
+
+/** One provider's ranked place in a comparison. */
+export interface OnrampQuoteComparison extends OnrampQuote {
+  providerName: string;
+  source: QuoteSource;
+  /** Epoch ms this quote's numbers were computed/fetched. */
+  quotedAt: number;
+  /** 1 = best (highest destination amount). Tied quotes share a rank (dense ranking). */
+  rank: number;
+  isBest: boolean;
+  limits: QuoteLimits | null;
+  /** Null when limits couldn't be parsed — "unknown" is not the same as "within". */
+  withinLimits: boolean | null;
+}
+
+/** A live quote fetched externally, for one provider. Same numbers an `OnrampQuote` carries. */
+export type LiveQuoteInput = Pick<OnrampQuote, "destinationAmount" | "fee" | "sourceAmount">;
+
+/**
+ * Parses a provider's `"$20 - $10,000"`-style limits string. Returns null
+ * (unknown, not "no limit") if the format ever changes and this can't keep
+ * up — callers must treat null as "can't tell", not as "unlimited".
+ */
+export function parseProviderLimits(limits: string): QuoteLimits | null {
+  const match = limits.match(/\$?([\d,]+(?:\.\d+)?)\s*-\s*\$?([\d,]+(?:\.\d+)?)/);
+  if (!match) return null;
+  const min = Number(match[1].replace(/,/g, ""));
+  const max = Number(match[2].replace(/,/g, ""));
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+  return { min, max };
+}
+
+/** True when `amount` falls within `limits`, inclusive. Null limits (unknown) are never "within". */
+export function isWithinLimits(amount: number, limits: QuoteLimits | null): boolean | null {
+  if (!limits) return null;
+  return amount >= limits.min && amount <= limits.max;
+}
+
+function providerMeta(id: OnrampProvider) {
+  const p = providers.find((provider) => provider.id === id);
+  if (!p) throw new Error(`Unknown onramp provider: ${id}`);
+  return p;
+}
+
+/**
+ * Builds this app's own fee-model estimate for one provider — the fallback
+ * every comparison entry uses when no live quote is available.
+ */
+export function buildEstimatedQuote(
+  providerId: OnrampProvider,
+  fiatAmount: number,
+  fiatCurrency: string,
+  now: number = Date.now()
+): OnrampQuoteComparison {
+  const meta = providerMeta(providerId);
+  const { fee, receive } = calculateOnrampFeeAndReceive(fiatAmount, providerId);
+  const limits = parseProviderLimits(meta.limits);
+  return {
+    provider: providerId,
+    providerName: meta.name,
+    sourceAmount: fiatAmount.toFixed(2),
+    destinationAmount: receive.toFixed(2),
+    fee: fee.toFixed(2),
+    fiatCurrency,
+    cryptoCurrency: "USDC",
+    source: "estimated",
+    quotedAt: now,
+    rank: 0, // filled in by rankQuotes
+    isBest: false,
+    limits,
+    withinLimits: isWithinLimits(fiatAmount, limits),
+  };
+}
+
+/** Turns an external live quote into a comparison entry, same shape as the estimate it replaces. */
+function toLiveComparison(
+  providerId: OnrampProvider,
+  fiatAmount: number,
+  fiatCurrency: string,
+  live: LiveQuoteInput,
+  now: number
+): OnrampQuoteComparison {
+  const meta = providerMeta(providerId);
+  const limits = parseProviderLimits(meta.limits);
+  return {
+    provider: providerId,
+    providerName: meta.name,
+    sourceAmount: live.sourceAmount,
+    destinationAmount: live.destinationAmount,
+    fee: live.fee,
+    fiatCurrency,
+    cryptoCurrency: "USDC",
+    source: "live",
+    quotedAt: now,
+    rank: 0,
+    isBest: false,
+    limits,
+    withinLimits: isWithinLimits(fiatAmount, limits),
+  };
+}
+
+/**
+ * Ranks a set of already-built comparison entries by destination amount
+ * (highest first) using dense ranking — equal quotes tie at the same rank
+ * rather than one arbitrarily edging out the other, and the rank after a tie
+ * skips ahead correctly (1, 1, 2 — not 1, 1, 3). Mutates nothing; returns a
+ * new sorted array.
+ */
+export function rankQuotes(quotes: OnrampQuoteComparison[]): OnrampQuoteComparison[] {
+  const sorted = [...quotes].sort(
+    (a, b) => Number(b.destinationAmount) - Number(a.destinationAmount)
+  );
+  let rank = 0;
+  let lastAmount: number | null = null;
+  return sorted.map((q) => {
+    const amount = Number(q.destinationAmount);
+    if (lastAmount === null || amount < lastAmount) {
+      rank += 1;
+      lastAmount = amount;
+    }
+    return { ...q, rank, isBest: rank === 1 };
+  });
+}
+
+/**
+ * Builds the ranked, side-by-side provider comparison for a given fiat
+ * amount/currency. Providers that don't support `fiatCurrency` are left out
+ * (same restriction the onramp form itself enforces) rather than shown with
+ * a quote they can't actually honour. A provider whose live quote is
+ * missing, or whose fetch failed upstream, silently falls back to this
+ * app's own estimate — provider-level failure never removes it from the
+ * comparison or breaks the others (each entry is independent).
+ */
+export function compareOnrampQuotes(
+  fiatAmount: number,
+  fiatCurrency: string,
+  options: {
+    liveQuotes?: Partial<Record<OnrampProvider, LiveQuoteInput>>;
+    now?: number;
+  } = {}
+): OnrampQuoteComparison[] {
+  if (!Number.isFinite(fiatAmount) || fiatAmount <= 0) return [];
+  const now = options.now ?? Date.now();
+  const liveQuotes = options.liveQuotes ?? {};
+
+  const entries = providers
+    .filter((p) => p.currencies.includes(fiatCurrency))
+    .map((p) => {
+      if (!isOnrampProvider(p.id)) return null; // defensive; providers[] ids are always OnrampProvider today
+      const live = liveQuotes[p.id];
+      return live
+        ? toLiveComparison(p.id, fiatAmount, fiatCurrency, live, now)
+        : buildEstimatedQuote(p.id, fiatAmount, fiatCurrency, now);
+    })
+    .filter((q): q is OnrampQuoteComparison => q !== null);
+
+  return rankQuotes(entries);
+}
+
+/** The top-ranked quote, or null for an empty comparison. */
+export function bestQuote(comparisons: OnrampQuoteComparison[]): OnrampQuoteComparison | null {
+  return comparisons.find((q) => q.isBest) ?? null;
+}
+
+/**
+ * The spread between the best and worst quote's destination amount — how
+ * much USDC picking the wrong provider would cost, in absolute terms and as
+ * a percentage of the best quote. Null when there's nothing to compare (0 or
+ * 1 entries).
+ */
+export function quoteSpread(
+  comparisons: OnrampQuoteComparison[]
+): { absolute: number; percent: number } | null {
+  if (comparisons.length < 2) return null;
+  const amounts = comparisons.map((q) => Number(q.destinationAmount));
+  const best = Math.max(...amounts);
+  const worst = Math.min(...amounts);
+  const absolute = best - worst;
+  return { absolute, percent: best > 0 ? (absolute / best) * 100 : 0 };
+}
+
+/** Re-derives fee rate as a percentage string for display, e.g. 0.045 -> "4.50%". Mirrors feeTiers.ts's formatFeeRate. */
+export function formatQuoteFeeRate(providerId: OnrampProvider): string {
+  return `${(getProviderFeeRate(providerId) * 100).toFixed(2)}%`;
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -10,6 +10,7 @@ export const ROUTES = {
   ONRAMP: '/onramp',
   CEX: '/cex',
   PROFILE: '/profile',
+  SCHEDULES: '/schedules',
 } as const;
 
 export type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];


### PR DESCRIPTION
Closes #554
Closes #555
Closes #556
Closes #557

## Summary

- **#556** — ranks Moonpay/Transak side-by-side for the entered amount and currency: rate/fee breakdown, best-quote highlight, spread between providers, and a 30s auto-refresh with a "quoted Xs ago" age display. `src/lib/onrampQuotes.ts` holds the pure comparison/ranking logic (dense-rank ties, so two equal quotes both show as best); `/api/onramp/quotes` is an optional live-quote proxy — this repo doesn't vendor a real provider quote API yet, so it's gated behind per-provider env vars and every entry falls back to the existing fee-model estimate when unconfigured or on failure. One provider's outage never blanks the others' quotes.
- **#557** — recurring funding schedules (weekly/biweekly/monthly) for a target C-address, stored client-side the same way `addressBook.ts` stores recipients (there's no backend, so nothing executes automatically). A due schedule surfaces via the notification centre's existing `"schedule"` kind (added in #477, unused until now) and offers a pre-filled bridge link via `fundingLink.ts` so completing it is a click, not a retyped address. New page at `/schedules`, linked from the navbar.
- **#554 / #555** — no code change in this diff. Both `isValidStellarAddress` and `isValidStellarAmount` are already correctly implemented on `main` (restored by commit `5d3fb70`, PR #593, after an unrelated seed/scaffolding commit had stubbed them). Linked here so merging this PR closes them out too, rather than leaving them open with nothing left to do.

## Test plan

- 65 new tests added (23 + 6 for #556, 42 + 12 for #557), all passing.
- Ran the full existing test suite before and after this change — the 99 pre-existing failures across 31 files (unrelated wallet/network/session/transaction-history tests) are identical before and after; none of the files this PR touches or adds appear in that list.
- `tsc --noEmit` and `eslint` clean on every changed/added file (one pre-existing unrelated warning in `navbar.tsx`, one pre-existing unrelated syntax-broken file `bridge/page.tsx`, neither touched by this PR).
